### PR TITLE
fix bug: potential null reference error

### DIFF
--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanel.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanel.cs
@@ -134,8 +134,8 @@ namespace Unity.UIWidgets.engine {
         const int mouseButtonNum = 3;
 
         void _handleViewMetricsChanged(string method, List<JSONNode> args) {
-            this._windowAdapter.onViewMetricsChanged();
-            this._displayMetrics.onViewMetricsChanged();
+            this._windowAdapte?.onViewMetricsChanged();
+            this._displayMetrics?.onViewMetricsChanged();
         }
 
         protected virtual void InitWindowAdapter() {

--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanel.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanel.cs
@@ -134,7 +134,7 @@ namespace Unity.UIWidgets.engine {
         const int mouseButtonNum = 3;
 
         void _handleViewMetricsChanged(string method, List<JSONNode> args) {
-            this._windowAdapte?.onViewMetricsChanged();
+            this._windowAdapter?.onViewMetricsChanged();
             this._displayMetrics?.onViewMetricsChanged();
         }
 


### PR DESCRIPTION
fix bug: potential null reference error when App goes from back to front and native calls _handleViewMetricsChanged before the window is initialized

This bug is reported by a user and this fix has been proved ok by him