### PR TITLE
Fix gif update issue

### DIFF
--- a/engine/src/shell/platform/unity/uiwidgets_system.cc
+++ b/engine/src/shell/platform/unity/uiwidgets_system.cc
@@ -28,9 +28,10 @@ void UIWidgetsSystem::Wait(std::chrono::nanoseconds max_duration) {
                next_uiwidgets_event_time_ - TimePoint::clock::now());
 
   wait_duration = std::min(max_duration, wait_duration);
+  wait_duration = std::max(std::chrono::nanoseconds(0), wait_duration);
 
   ::MsgWaitForMultipleObjects(0, nullptr, FALSE,
-                              static_cast<DWORD>(wait_duration.count() / 1000),
+                              static_cast<DWORD>(wait_duration.count() / 1000000),
                               QS_ALLINPUT);
 }
 


### PR DESCRIPTION
the issue might be caused by the following two reasons:
(1) The "max_duration" is negative, which seems to be impossible however happens sometimes (it comes from the Engine). So we add a protection to address this problem.
(2) The wait_duration.count() returns nanoseconds while the MsgWaitForMultipleObjects need milliseconds (https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-msgwaitformultipleobjects), and 1 millisecond = 1000,000 nanoseconds. We fix the code a bit to make the ratio correct.