### PR TITLE
temporary fix on editor crash (2019.4.26f1c1)

### DIFF
--- a/engine/src/shell/platform/unity/android/uiwidgets_system.h
+++ b/engine/src/shell/platform/unity/android/uiwidgets_system.h
@@ -30,11 +30,11 @@ class UIWidgetsSystem {
 
   void PostTaskToGfxWorker(const fml::closure& task);
   void printf_console(const char* log, ...) {
-    va_list vl;
+    /*va_list vl;
     va_start(vl, log);
     // TODO: error in __android_log_vprint -> vsnprintf -> __vfprintf -> strlen_a
     // unity_uiwidgets_->printf_consolev(log, vl);
-    va_end(vl);
+    va_end(vl);*/
   }
 
   void BindUnityInterfaces(IUnityInterfaces* unity_interfaces);

--- a/engine/src/shell/platform/unity/darwin/ios/uiwidgets_system.h
+++ b/engine/src/shell/platform/unity/darwin/ios/uiwidgets_system.h
@@ -29,10 +29,10 @@ class UIWidgetsSystem {
 
   void PostTaskToGfxWorker(const fml::closure& task);
   void printf_console(const char* log, ...) {
-    va_list vl;
+    /*va_list vl;
     va_start(vl, log);
     unity_uiwidgets_->printf_consolev(log, vl);
-    va_end(vl);
+    va_end(vl);*/
   }
 
   void BindUnityInterfaces(IUnityInterfaces* unity_interfaces);

--- a/engine/src/shell/platform/unity/darwin/macos/uiwidgets_system.h
+++ b/engine/src/shell/platform/unity/darwin/macos/uiwidgets_system.h
@@ -29,10 +29,10 @@ class UIWidgetsSystem {
 
   void PostTaskToGfxWorker(const fml::closure& task);
   void printf_console(const char* log, ...) {
-    va_list vl;
+    /*va_list vl;
     va_start(vl, log);
     unity_uiwidgets_->printf_consolev(log, vl);
-    va_end(vl);
+    va_end(vl);*/
   }
 
   void BindUnityInterfaces(IUnityInterfaces* unity_interfaces);

--- a/engine/src/shell/platform/unity/windows/uiwidgets_system.h
+++ b/engine/src/shell/platform/unity/windows/uiwidgets_system.h
@@ -29,10 +29,10 @@ class UIWidgetsSystem {
 
   void PostTaskToGfxWorker(const fml::closure& task);
   void printf_console(const char* log, ...) {
-    va_list vl;
+    /*va_list vl;
     va_start(vl, log);
     unity_uiwidgets_->printf_consolev(log, vl);
-    va_end(vl);
+    va_end(vl);*/
   }
 
   void BindUnityInterfaces(IUnityInterfaces* unity_interfaces);

--- a/engine/third_party/Unity/IUnityUIWidgets.h
+++ b/engine/third_party/Unity/IUnityUIWidgets.h
@@ -20,7 +20,9 @@ UNITY_DECLARE_INTERFACE(IUnityUIWidgets) {
   virtual void SetWakeUpCallback(VoidCallback callback) = 0;
   virtual void IssuePluginEventAndData(UnityRenderingEventAndData callback,
                                        int eventId, void* data) = 0;
-  virtual void printf_consolev(const char* log, va_list alist) = 0;
+  //TODO zxw: this API is not provided in 2019.4.26f1c1 due to a mistake :(
+  //we should consider adding it back later (remember to enable all callers too)
+  //virtual void printf_consolev(const char* log, va_list alist) = 0;
 };
 }  // namespace UnityUIWidgets
 


### PR DESCRIPTION
printf_consolev API is not added to 2019.4.26f1c1 yet, therefore we have to disable this api by now to avoid blocking the editor release procedure