### PR TITLE
fix invalid texture size issue

### DIFF
--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanelWrapper.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanelWrapper.cs
@@ -270,6 +270,9 @@ public partial class UIWidgetsPanelWrapper {
         }
 
         bool _recreateRenderTexture(int width, int height, float devicePixelRatio) {
+            width = Mathf.Max(1, width);
+            height = Mathf.Max(1, height);
+            
             if (renderTexture != null && _width == width && _height == height &&
                 this.devicePixelRatio == devicePixelRatio) {
                 return false;


### PR DESCRIPTION
unity will report error if the external texture's width or height is 0. In this PR, we fix it