### PR TITLE
Handle touches on mobile

### DIFF
--- a/Samples/UIWidgetsSamples_2019_4/Assets/WidgetsSample/MobileTouchSample.cs
+++ b/Samples/UIWidgetsSamples_2019_4/Assets/WidgetsSample/MobileTouchSample.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using uiwidgets;
+using Unity.UIWidgets.engine;
+using Unity.UIWidgets.foundation;
+using Unity.UIWidgets.material;
+using Unity.UIWidgets.rendering;
+using Unity.UIWidgets.ui;
+using Unity.UIWidgets.widgets;
+using UnityEngine;
+using UnityEngine.Networking;
+using Image = Unity.UIWidgets.widgets.Image;
+using ui_ = Unity.UIWidgets.widgets.ui_;
+
+namespace UIWidgetsSample
+{
+    public class MobileTouchSample : UIWidgetsPanel
+    {
+        protected override void main()
+        {
+            ui_.runApp(new MaterialApp(
+                title: "Http Request Sample",
+                home: new Scaffold(
+                    body: new MobileTouchWidget()
+                )
+            ));
+        }
+    }
+
+    public class MobileTouchWidget : StatefulWidget
+    {
+        public MobileTouchWidget(Key key = null) : base(key)
+        {
+        }
+
+        public override State createState()
+        {
+            return new MobileTouchWidgetState();
+        }
+    }
+
+    class MobileTouchWidgetState : State<MobileTouchWidget>
+    {
+        private float scale = 1;
+        private int frameNo = 0;
+        private float rotation = 0;
+
+        public override Widget build(BuildContext context)
+        {
+            return new Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: new List<Widget>()
+                {
+                    new Text("Frame: " + frameNo),
+                    new Text("Scale: " + scale),
+                    new Text("Rotation: " + rotation),
+                    new GestureDetector(
+                        child: new Container(height: 300, color: Colors.blue),
+                        onScaleStart: details => { },
+                        onScaleUpdate: details =>
+                        {
+                            scale = details.scale;
+                            rotation = details.rotation;
+                            frameNo += 1;
+                            setState(() => { });
+                        },
+                        onScaleEnd: details => { }
+                    )
+                });
+        }
+    }
+}

--- a/com.unity.uiwidgets/Runtime/Plugins/Android/libUIWidgets.so
+++ b/com.unity.uiwidgets/Runtime/Plugins/Android/libUIWidgets.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1da51fd7da36b323f17882f7ddaabbb5a08c09ce5e649821a1f242927da4974f
-size 76055048
+oid sha256:39792c1a15937910cf2938e3e9937422e3520dab4a14b09f3e8fbf91a233db52
+size 76747900

--- a/com.unity.uiwidgets/Runtime/Plugins/ios/libUIWidgets.a
+++ b/com.unity.uiwidgets/Runtime/Plugins/ios/libUIWidgets.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee599723799bd2fd383fd8e36407ab66072cf01d6df48a349efe8ee9e6300b25
-size 247466888
+oid sha256:845d1eb0cab9827127f8758e5393fbc12191fae907edffab8a2d29db5425c945
+size 247828112

--- a/com.unity.uiwidgets/Runtime/Plugins/osx/libUIWidgets.dylib
+++ b/com.unity.uiwidgets/Runtime/Plugins/osx/libUIWidgets.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16d2be3e47cfadfd0bbb33aabe4edc5a18e04dd122172b5f9fa855d04e8158ee
-size 21817320
+oid sha256:45bc8d2b586ede8e9dae7ce5f660b4cbadf0994d0d7b4d28e7c2fd6211d116fa
+size 21819832

--- a/com.unity.uiwidgets/Runtime/Plugins/x86_64/libUIWidgets.dll
+++ b/com.unity.uiwidgets/Runtime/Plugins/x86_64/libUIWidgets.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8db63b6dfb62799c6decd05c92136208ae0dcce6eb3d545bbda1e19594e9ba75
-size 11256320
+oid sha256:49701553366d65e4ed4f03b9d8534c47f4bc9bd5b847dffbe3c11e19033d9264
+size 11258880

--- a/com.unity.uiwidgets/Runtime/Plugins/x86_64/libUIWidgets.dll.meta
+++ b/com.unity.uiwidgets/Runtime/Plugins/x86_64/libUIWidgets.dll.meta
@@ -12,33 +12,52 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 0
+        Exclude Win64: 0
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: x86_64
         DefaultValueInitialized: true
+        OS: AnyOS
   - first:
       Standalone: Linux64
     second:
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: x86_64
   - first:
       Standalone: Win
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: None
   - first:
@@ -47,6 +66,15 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanelWrapper.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanelWrapper.cs
@@ -289,8 +289,8 @@ public partial class UIWidgetsPanelWrapper {
             if (pos == null) {
                 return;
             }
-
-            UIWidgetsPanel_onMouseMove(ptr: _ptr, x: pos.Value.x, y: pos.Value.y);
+            
+            UIWidgetsPanel_onMouseMove(ptr: _ptr, x: pos.Value.x, y: pos.Value.y, -1);
         }
 
         public void OnMouseScroll(Vector2 delta, Vector2? pos) {
@@ -330,7 +330,7 @@ public partial class UIWidgetsPanelWrapper {
 
             // mouse event
             if (pointerId < 0) {
-                UIWidgetsPanel_onMouseMove(ptr: _ptr, x: pos.Value.x, y: pos.Value.y);
+                UIWidgetsPanel_onMouseMove(ptr: _ptr, x: pos.Value.x, y: pos.Value.y, pointerId);
             }
         }
 
@@ -360,7 +360,7 @@ public partial class UIWidgetsPanelWrapper {
         static extern void UIWidgetsPanel_onMouseUp(IntPtr ptr, float x, float y, int button);
 
         [DllImport(dllName: NativeBindings.dllName)]
-        static extern void UIWidgetsPanel_onMouseMove(IntPtr ptr, float x, float y);
+        static extern void UIWidgetsPanel_onMouseMove(IntPtr ptr, float x, float y, int button);
 
         [DllImport(dllName: NativeBindings.dllName)]
         static extern void UIWidgetsPanel_onMouseLeave(IntPtr ptr);

--- a/engine/Scripts/lib_build.py
+++ b/engine/Scripts/lib_build.py
@@ -127,7 +127,7 @@ def set_env_verb():
     global flutter_root_path
     flutter_root_path = os.getenv('FLUTTER_ROOT_PATH', 'null')
     if flutter_root_path == 'null':
-        os.environ["FLUTTER_ROOT_PATH"] = engine_path + "/engine/src"
+        os.environ["FLUTTER_ROOT_PATH"] = os.path.join(engine_path, "engine","src")
         flutter_root_path = os.getenv('FLUTTER_ROOT_PATH')
     else:
         print("This environment variable has been set, skip")

--- a/engine/src/shell/platform/unity/android/uiwidgets_panel.cc
+++ b/engine/src/shell/platform/unity/android/uiwidgets_panel.cc
@@ -561,7 +561,7 @@ namespace uiwidgets
   }
 
   UIWIDGETS_API(void)
-  UIWidgetsPanel_onMouseMove(UIWidgetsPanel *panel, float x, float y)
+  UIWidgetsPanel_onMouseMove(UIWidgetsPanel *panel, float x, float y, int button)
   {
     panel->OnMouseMove(x, y);
   }

--- a/engine/src/shell/platform/unity/darwin/macos/uiwidgets_panel.mm
+++ b/engine/src/shell/platform/unity/darwin/macos/uiwidgets_panel.mm
@@ -493,7 +493,8 @@ UIWidgetsPanel_onMouseUp(UIWidgetsPanel* panel, float x, float y, int button) {
 }
 
 UIWIDGETS_API(void)
-UIWidgetsPanel_onMouseMove(UIWidgetsPanel* panel, float x, float y) {
+UIWidgetsPanel_onMouseMove(UIWidgetsPanel* panel, float x, float y, int button) {
+  //button id is not useful for desktop since the motions happens on the mouse (including all buttons)
   panel->OnMouseMove(x, y);
 }
 

--- a/engine/src/shell/platform/unity/windows/uiwidgets_panel.cc
+++ b/engine/src/shell/platform/unity/windows/uiwidgets_panel.cc
@@ -539,7 +539,8 @@ UIWidgetsPanel_onMouseUp(UIWidgetsPanel* panel, float x, float y, int button) {
 }
 
 UIWIDGETS_API(void)
-UIWidgetsPanel_onMouseMove(UIWidgetsPanel* panel, float x, float y) {
+UIWidgetsPanel_onMouseMove(UIWidgetsPanel* panel, float x, float y, int button) {
+  //button id is not useful for desktop since the motions happens on the mouse (including all buttons)
   panel->OnMouseMove(x, y);
 }
 


### PR DESCRIPTION
This PR fixes multi-touch support issue on mobile devices.

The previous codes for user input handler on mobiles are directly copied from desktop handler, which turns out to be buggy: the key issue is that, while a MouseMove event on desktop cannot be deliver to any specific mouse button (when the mouse is moving, all buttons (left, right, .etc) are moving at the same time), each TouchMove event on mobile should be assigned to one specific touch id. 

To resolve this issue, I tried to change our code according to the input handling logics on ios for flutter (https://github.com/flutter/engine/blob/flutter-1.17-candidate.5/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm).

You can use the MobileTouchSample to test this PR.