### PR TITLE
vsync issue work-around

### DIFF
--- a/com.unity.uiwidgets/Runtime/Plugins/Android/libUIWidgets.so
+++ b/com.unity.uiwidgets/Runtime/Plugins/Android/libUIWidgets.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39792c1a15937910cf2938e3e9937422e3520dab4a14b09f3e8fbf91a233db52
-size 76747900
+oid sha256:a3210034835bd953a1ff906fffc465f41eed383d3084291ffcc3104b2dd33eac
+size 76745884

--- a/com.unity.uiwidgets/Runtime/Plugins/ios/libUIWidgets.a
+++ b/com.unity.uiwidgets/Runtime/Plugins/ios/libUIWidgets.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:845d1eb0cab9827127f8758e5393fbc12191fae907edffab8a2d29db5425c945
-size 247828112
+oid sha256:396a30ebbb3f08f5b1521b31a8cb153ad7b018872bd7b048c115ca5e794de804
+size 247821744

--- a/com.unity.uiwidgets/Runtime/Plugins/osx/libUIWidgets.dylib
+++ b/com.unity.uiwidgets/Runtime/Plugins/osx/libUIWidgets.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45bc8d2b586ede8e9dae7ce5f660b4cbadf0994d0d7b4d28e7c2fd6211d116fa
-size 21819832
+oid sha256:56d3a89a2b7c6ad6f8f95299151fddc139f422261081af729bcd048e3644eb4d
+size 21819568

--- a/engine/src/shell/platform/unity/android/uiwidgets_system.cc
+++ b/engine/src/shell/platform/unity/android/uiwidgets_system.cc
@@ -21,16 +21,11 @@ void UIWidgetsSystem::UnregisterPanel(UIWidgetsPanel* panel) {
 }
 
 void UIWidgetsSystem::Wait(std::chrono::nanoseconds max_duration) {
-  Update();
-
-  std::chrono::nanoseconds wait_duration =
-      std::max(std::chrono::nanoseconds(0),
-               next_uiwidgets_event_time_ - TimePoint::clock::now());
-
-  wait_duration = std::min(max_duration, wait_duration);
-
-  //TODO: find a proper api similar to MsgWaitForMultipleObjects on Windows
-  //      which will notify os to wait for the given period of time
+  //TODO zxw: Rename this function to VSync, should be done after Engine side changes land
+  //Process VSync at the end of this frame
+  for (auto* uiwidgets_panel : uiwidgets_panels_) {
+    uiwidgets_panel->ProcessVSync();
+  }
 }
 
 void UIWidgetsSystem::Update() {
@@ -46,9 +41,7 @@ void UIWidgetsSystem::Update() {
 }
 
 void UIWidgetsSystem::VSync() {
-  for (auto* uiwidgets_panel : uiwidgets_panels_) {
-    uiwidgets_panel->ProcessVSync();
-  }
+  //TODO zxw: Remove this function, should be done after Engine side changes land
 }
 
 void UIWidgetsSystem::WakeUp() {}

--- a/engine/src/shell/platform/unity/darwin/ios/uiwidgets_system.mm
+++ b/engine/src/shell/platform/unity/darwin/ios/uiwidgets_system.mm
@@ -21,16 +21,14 @@ void UIWidgetsSystem::UnregisterPanel(UIWidgetsPanel* panel) {
 }
 
 void UIWidgetsSystem::Wait(std::chrono::nanoseconds max_duration) {
-  Update();
-
-  std::chrono::nanoseconds wait_duration =
-      std::max(std::chrono::nanoseconds(0),
-               next_uiwidgets_event_time_ - TimePoint::clock::now());
-
-  wait_duration = std::min(max_duration, wait_duration);
-
-  //TODO: find a proper api similar to MsgWaitForMultipleObjects on Windows
-  //      which will notify os to wait for the given period of time
+  //TODO zxw: Rename this function to VSync, should be done after Engine side changes land
+  //Process VSync at the end of this frame
+  for (auto* uiwidgets_panel : uiwidgets_panels_) {
+    if (!uiwidgets_panel->NeedUpdateByPlayerLoop()) {
+      continue;
+    }
+    uiwidgets_panel->ProcessVSync();
+  }
 }
 
 void UIWidgetsSystem::Update() {
@@ -49,12 +47,7 @@ void UIWidgetsSystem::Update() {
 }
 
 void UIWidgetsSystem::VSync() {
-  for (auto* uiwidgets_panel : uiwidgets_panels_) {
-    if (!uiwidgets_panel->NeedUpdateByPlayerLoop()) {
-      continue;
-    }
-    uiwidgets_panel->ProcessVSync();
-  }
+  //TODO zxw: Remove this function, should be done after Engine side changes land
 }
 
 void UIWidgetsSystem::WakeUp() {}

--- a/engine/src/shell/platform/unity/darwin/macos/uiwidgets_system.mm
+++ b/engine/src/shell/platform/unity/darwin/macos/uiwidgets_system.mm
@@ -21,16 +21,14 @@ void UIWidgetsSystem::UnregisterPanel(UIWidgetsPanel* panel) {
 }
 
 void UIWidgetsSystem::Wait(std::chrono::nanoseconds max_duration) {
-  Update();
-
-  std::chrono::nanoseconds wait_duration =
-      std::max(std::chrono::nanoseconds(0),
-               next_uiwidgets_event_time_ - TimePoint::clock::now());
-
-  wait_duration = std::min(max_duration, wait_duration);
-
-  //TODO: find a proper api similar to MsgWaitForMultipleObjects on Windows
-  //      which will notify os to wait for the given period of time
+  //TODO zxw: Rename this function to VSync, should be done after Engine side changes land
+  //Process VSync at the end of this frame
+  for (auto* uiwidgets_panel : uiwidgets_panels_) {
+    if (!uiwidgets_panel->NeedUpdateByPlayerLoop()) {
+      continue;
+    }
+    uiwidgets_panel->ProcessVSync();
+  }
 }
 
 void UIWidgetsSystem::Update() {
@@ -49,12 +47,7 @@ void UIWidgetsSystem::Update() {
 }
 
 void UIWidgetsSystem::VSync() {
-  for (auto* uiwidgets_panel : uiwidgets_panels_) {
-    if (!uiwidgets_panel->NeedUpdateByPlayerLoop()) {
-      continue;
-    }
-    uiwidgets_panel->ProcessVSync();
-  }
+  //TODO zxw: Remove this function, should be done after Engine side changes land
 }
 
 void UIWidgetsSystem::WakeUp() {}

--- a/engine/src/shell/platform/unity/windows/uiwidgets_system.cc
+++ b/engine/src/shell/platform/unity/windows/uiwidgets_system.cc
@@ -21,7 +21,17 @@ void UIWidgetsSystem::UnregisterPanel(UIWidgetsPanel* panel) {
 }
 
 void UIWidgetsSystem::Wait(std::chrono::nanoseconds max_duration) {
-  Update();
+  //TODO zxw: Rename this function to VSync, should be done after Engine side changes land
+  //Process VSync at the end of this frame
+  for (auto* uiwidgets_panel : uiwidgets_panels_) {
+    if (!uiwidgets_panel->NeedUpdateByPlayerLoop()) {
+      continue;
+    }
+    uiwidgets_panel->ProcessVSync();
+  }
+
+  //TODO zxw: Move this function to a better place
+  /*Update();
 	
   std::chrono::nanoseconds wait_duration =
       std::max(std::chrono::nanoseconds(0),
@@ -32,7 +42,7 @@ void UIWidgetsSystem::Wait(std::chrono::nanoseconds max_duration) {
 
   ::MsgWaitForMultipleObjects(0, nullptr, FALSE,
                               static_cast<DWORD>(wait_duration.count() / 1000000),
-                              QS_ALLINPUT);
+                              QS_ALLINPUT);*/
 }
 
 void UIWidgetsSystem::Update() {
@@ -51,12 +61,7 @@ void UIWidgetsSystem::Update() {
 }
 
 void UIWidgetsSystem::VSync() {
-  for (auto* uiwidgets_panel : uiwidgets_panels_) {
-    if (!uiwidgets_panel->NeedUpdateByPlayerLoop()) {
-      continue;
-    }
-    uiwidgets_panel->ProcessVSync();
-  }
+  //TODO zxw: Remove this function, should be done after Engine side changes land
 }
 
 void UIWidgetsSystem::WakeUp() {}


### PR DESCRIPTION
This PR fixes two issues:
(1) UIWidgetsSystem::Wait is triggered after WaitForTargetFPS call in Unity (If the current frame cost N ms, the WaitForTargetFPS will stop the main thread for 16-N ms) where we will call Update() and trigger costly "drawFrame" callbacks in the ui thread task pool. As the result, the frame rate will drop since the wait time is wrong (The wait time should be 16 - N - cost-of-UIWidgetsSystem::Wait, instead of 16 - N). Current solution is to remove Update() from it.

(2) In our code we hard-coded the interval between each two VSyncs as 1/60 s. However, currently this is not true (the internval of two VSyncs depends on the "Wait" duration of the previous frame and the "Update" duration of the following frame, which is not guaranteed to be 1/60 s at any time), therefore the UI animation is not fluent. Current solution is to move VSync calls to the end of each frame (i.e., inside the UIWidgetsSystem::Wait function) so the animation will be fluent if the PFS is 60.

IMPORTANT: this PR is only a temporary work-around. We should eventually fix this issue on the Unity Engine side.