### PR TITLE
Fix runtime debug

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -211,8 +211,6 @@ UIWidgets也支持Gif！
 
 在编辑器菜单栏选择```UIWidgets->EnableDebug```
 
-如果想在runtime开启debug模式，请在项目代码中设置```UIWidgetsGlobalConfiguration.EnableDebugAtRuntime = true```。在默认情况下debug模式为关闭状态。
-
 ## 使用Window Scope保护外部调用
 如果您在调试时遇到 `AssertionError: Window.instance is null` 或者在调用 `Window.instance` 时得到空指针, 那么您需要
 使用以下方式来保护您的调用，使之可以在正确的Isolate上执行回调逻辑：

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -209,7 +209,9 @@ UIWidgets也支持Gif！
 
 ## 调试UIWidgets应用程序
 
-在编辑器菜单栏选择```UIWidgets->EnableDebug```
+在Editor模式下，编辑器菜单栏选择```UIWidgets->EnableDebug```。
+
+在Runtime模式下，Debug/Development build会自动开启Debug，Release build则会自动关闭Debug。
 
 ## 使用Window Scope保护外部调用
 如果您在调试时遇到 `AssertionError: Window.instance is null` 或者在调用 `Window.instance` 时得到空指针, 那么您需要

--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ Long time garbage collection may cause App to stuck frequently. You can enable i
 
 ## Debug UIWidgets Application
 
-You can switch debug/release mode by “UIWidgets->EnableDebug” in the Unity Editor.
+In the Editor, you can switch debug/release mode by “UIWidgets->EnableDebug”.
+
+In the Player, the debug/development build will enable debug mode. The release build will disable debug mode automatically.
 
 ## Using Window Scope
 If you see the error `AssertionError: Window.instance is null` or null pointer error of `Window.instance`,

--- a/README.md
+++ b/README.md
@@ -220,9 +220,7 @@ Long time garbage collection may cause App to stuck frequently. You can enable i
 
 ## Debug UIWidgets Application
 
-In Unity editor, you can switch debug/release mode by “UIWidgets->EnableDebug”.
-
-You can also enable debug mode in runtime by setting ```UIWidgetsGlobalConfiguration.EnableDebugAtRuntime = true``` in your project. Note that this value is set to false by default.
+You can switch debug/release mode by “UIWidgets->EnableDebug” in the Unity Editor.
 
 ## Using Window Scope
 If you see the error `AssertionError: Window.instance is null` or null pointer error of `Window.instance`,

--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsGlobalConfiguration.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsGlobalConfiguration.cs
@@ -5,8 +5,5 @@ namespace Unity.UIWidgets.engine {
 
         //disable incremental gc by default
         public static bool EnableIncrementalGC = false;
-        
-        //disable debug at runtime by default
-        public static bool EnableDebugAtRuntime = false;
     }
 }

--- a/com.unity.uiwidgets/Runtime/foundation/debug.cs
+++ b/com.unity.uiwidgets/Runtime/foundation/debug.cs
@@ -54,8 +54,6 @@ namespace Unity.UIWidgets.foundation {
 
         public static bool debugPrintMouseHoverEvents = false;
 
-        public const string debugScriptingDefineSymbol = "DebugUIWidgets";
-
         public static HSVColor debugCurrentRepaintColor =
             HSVColor.fromAHSV(0.4f, 60.0f, 1.0f, 1.0f);
 
@@ -65,14 +63,14 @@ namespace Unity.UIWidgets.foundation {
             Debug.LogException(new AssertionError(message: message, innerException: ex));
         }
 
-        [Conditional(debugScriptingDefineSymbol)]
+        [Conditional("UNITY_ASSERTIONS")]
         public static void assert(Func<bool> result, Func<string> message = null) {
             if ( enableDebug && !result() ) {
                 throw new AssertionError(message != null ? message() : "");
             }
         }
         
-        [Conditional(debugScriptingDefineSymbol)]
+        [Conditional("UNITY_ASSERTIONS")]
         public static void assert(bool result, Func<string> message = null) {
             if ( enableDebug && !result ) {
                 throw new AssertionError(message != null ? message() : "");
@@ -82,23 +80,6 @@ namespace Unity.UIWidgets.foundation {
 #if UNITY_EDITOR
         static bool? _enableDebug = null;
 
-        private static void setRuntimeSymbolsForTarget(BuildTargetGroup targetGroup, bool enabled) {
-            string defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(targetGroup);
-            var defineList = defines.Split(';');
-            var newDefineList = new List<string>();
-            foreach (var define in defineList) {
-                if (define != debugScriptingDefineSymbol) {
-                    newDefineList.Add(define);
-                }
-            }
-
-            if (enabled) {
-                newDefineList.Add(debugScriptingDefineSymbol);
-            }
-            
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(targetGroup, String.Join(";", newDefineList));
-        }
-        
         public static bool enableDebug {
             get {
                 if (_enableDebug == null) {
@@ -112,13 +93,11 @@ namespace Unity.UIWidgets.foundation {
                 }
                 _enableDebug = value;
                 EditorPrefs.SetInt("UIWidgetsDebug",value ? 1 : 0);
-                setRuntimeSymbolsForTarget(BuildTargetGroup.Android, value);
-                setRuntimeSymbolsForTarget(BuildTargetGroup.iOS, value);
-                setRuntimeSymbolsForTarget(BuildTargetGroup.Standalone, value);
             }
         }
 #else
-        //In runtime, we use the Conditional decorator "debugScriptingDefineSymbol" instead of this to enable/disable debug mode 
+        //In the runtime, we use the Conditional decorator instead of this to enable/disable debug mode
+        //The rule is simple: the debug mode is on for Debug/Development build, and is off for Release build
         public static bool enableDebug => true;
 #endif
 


### PR DESCRIPTION
EnableDebugAtRuntime is not very useful because the cost of the construction of the lambda functions (as the first parameter of D.assert(Func<bool> result, Func<string> message = null)) is still big enough to affect the performance significantly. 

So we just remove it here so that it won't mislead the user to use this for performance profiling in debug/development builds.

Using this PR, the rules now is very simple: In a standalonePlayer, the debug mode is on for debug/development build, and is off for release build.
