### PR TITLE
Fixing an error and some warnings.

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -111,7 +111,7 @@ UIWidgets应用是用**C＃脚本**来编写的。 请按照以下步骤创建�
 
     namespace UIWidgetsSample
     {
-        public class CountDemo : UIWidgetsPanel
+        public class UIWidgetsExample : UIWidgetsPanel
         {
             protected void OnEnable()
             {

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ in Unity Editor.
 
     namespace UIWidgetsSample
     {
-        public class CountDemo : UIWidgetsPanel
+        public class UIWidgetsExample : UIWidgetsPanel
         {
             protected void OnEnable()
             {

--- a/com.unity.uiwidgets/Runtime/cupertino/route.cs
+++ b/com.unity.uiwidgets/Runtime/cupertino/route.cs
@@ -357,7 +357,7 @@ namespace Unity.UIWidgets.cupertino {
         }
 
 
-        public string barrierLabel {
+        public override string barrierLabel {
             get { return null; }
         }
 

--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanel.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanel.cs
@@ -276,7 +276,7 @@ namespace Unity.UIWidgets.engine {
         }
 
 
-        protected void OnEnable() {
+        protected override void OnEnable() {
             if (UIWidgetsDisabled) {
                 enabled = false;
                 return;

--- a/com.unity.uiwidgets/Runtime/material/slider.cs
+++ b/com.unity.uiwidgets/Runtime/material/slider.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using uiwidgets;
 using Unity.UIWidgets.animation;
 using Unity.UIWidgets.async;
-using Unity.UIWidgets.async;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.gestures;
 using Unity.UIWidgets.painting;

--- a/com.unity.uiwidgets/Runtime/material/tooltip.cs
+++ b/com.unity.uiwidgets/Runtime/material/tooltip.cs
@@ -2,7 +2,6 @@ using System;
 using uiwidgets;
 using Unity.UIWidgets.animation;
 using Unity.UIWidgets.async;
-using Unity.UIWidgets.async;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.gestures;
 using Unity.UIWidgets.painting;

--- a/com.unity.uiwidgets/Runtime/scheduler/binding.cs
+++ b/com.unity.uiwidgets/Runtime/scheduler/binding.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Text;
 using developer;
 using Unity.UIWidgets.async;
-using Unity.UIWidgets.async;
 using Unity.UIWidgets.engine;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.painting;


### PR DESCRIPTION
- Fix an error in the tutorial script, otherwise we wouldn't be able to add script component to the canvas panel because the script
class cannot be found.

- Fix some warnings shown up in the console of Unity Editor after loading the UIWidgets package.