### PR TITLE
remove duplicated willPop()

### DIFF
--- a/com.unity.uiwidgets/Runtime/widgets/routes.cs
+++ b/com.unity.uiwidgets/Runtime/widgets/routes.cs
@@ -859,23 +859,7 @@ namespace Unity.UIWidgets.widgets {
             _ModalScopeStatus widget = context.dependOnInheritedWidgetOfExactType<_ModalScopeStatus>();
             return widget?.route as ModalRoute<T>;
         }
-        public new GlobalKey<_ModalScopeState<T>> _scopeKey = new LabeledGlobalKey<_ModalScopeState<T>>();
 
-        public override Future<RoutePopDisposition> willPop() {
-            //async
-            _ModalScopeState<T> scope = _scopeKey.currentState as _ModalScopeState<T> ;
-            D.assert(scope != null);
-
-            bool result = false;
-            foreach (WillPopCallback callback in _willPopCallbacks) {
-                callback.Invoke().then(v => result = !(bool)v);
-                if (result) {
-                    return Future.value(RoutePopDisposition.doNotPop).to<RoutePopDisposition>();
-                }
-            }
-            return base.willPop();
-            
-        }
         public override Widget _buildModalScope(BuildContext context) {
             return _modalScopeCache = _modalScopeCache ?? new _ModalScope<T>(key: _scopeKey, route: this);
         }


### PR DESCRIPTION
the willPop() function in ModalRoute<T>  is the same as in ModalRoute. But the new "scopeKey" hides the variable of the same name defined in ModalRoute: As the result, the original scopeKey in the willPop() function in ModalRoute cannot be correctly set.

I believe it is ok to remove the duplicated implementation of willPop() here hence avoid the duplicated definition of "scopeKey" issue 