### PR TITLE
[DONT MERGE] Mark DataContract and DataMember in UIWidgets classes.

### DIFF
--- a/com.unity.uiwidgets/Runtime/foundation/change_notifier.cs
+++ b/com.unity.uiwidgets/Runtime/foundation/change_notifier.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Linq;
 using Unity.UIWidgets.ui;
 
@@ -20,6 +21,7 @@ namespace Unity.UIWidgets.foundation {
         T value { get; }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.foundation")]
     public class ChangeNotifier : Listenable {
         ObserverList<VoidCallback> _listeners = new ObserverList<VoidCallback>();
 

--- a/com.unity.uiwidgets/Runtime/foundation/diagnostics.cs
+++ b/com.unity.uiwidgets/Runtime/foundation/diagnostics.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Linq;
 using System.Text;
 using Unity.UIWidgets.external;
@@ -2357,6 +2358,7 @@ namespace Unity.UIWidgets.foundation {
         void debugFillProperties(DiagnosticPropertiesBuilder properties);
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.foundation")]
     public abstract class Diagnosticable : IDiagnosticable {
 
         protected Diagnosticable() {

--- a/com.unity.uiwidgets/Runtime/painting/alignment.cs
+++ b/com.unity.uiwidgets/Runtime/painting/alignment.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Runtime.Serialization;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.ui;
 using UnityEngine;
 using Rect = Unity.UIWidgets.ui.Rect;
 
 namespace Unity.UIWidgets.painting {
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public abstract class AlignmentGeometry : IEquatable<AlignmentGeometry> {
         public AlignmentGeometry() {
         }
@@ -115,14 +117,17 @@ namespace Unity.UIWidgets.painting {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public class Alignment : AlignmentGeometry, IEquatable<Alignment> {
         public Alignment(float x, float y) {
             this.x = x;
             this.y = y;
         }
 
+        [DataMember]
         public readonly float x;
 
+        [DataMember]
         public readonly float y;
 
         public static readonly Alignment topLeft = new Alignment(-1.0f, -1.0f);
@@ -318,24 +323,28 @@ namespace Unity.UIWidgets.painting {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public class AlignmentDirectional : AlignmentGeometry {
         public AlignmentDirectional(float start, float y) {
             this.start = start;
             this.y = y;
         }
 
+        [DataMember]
         readonly float _px;
 
         protected override float _x {
             get => 0;
         }
 
+        [DataMember]
         readonly float start;
 
         protected override float _start {
             get => start;
         }
 
+        [DataMember]
         readonly float y;
 
         protected override float _y {
@@ -440,7 +449,7 @@ namespace Unity.UIWidgets.painting {
         public override string ToString() => _stringify(start, y);
     }
 
-
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     class _MixedAlignment : AlignmentGeometry {
         internal _MixedAlignment(float _x, float _start, float _y) {
             _px = _x;
@@ -448,18 +457,21 @@ namespace Unity.UIWidgets.painting {
             _py = _y;
         }
 
+        [DataMember]
         readonly float _px;
 
         protected override float _x {
             get => _px;
         }
 
+        [DataMember]
         readonly float _pstart;
 
         protected override float _start {
             get => _pstart;
         }
 
+        [DataMember]
         readonly float _py;
 
         protected override float _y {
@@ -511,6 +523,7 @@ namespace Unity.UIWidgets.painting {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public class TextAlignVertical {
         public TextAlignVertical(float y) {
             D.assert(y != null);
@@ -518,6 +531,7 @@ namespace Unity.UIWidgets.painting {
             this.y = y;
         }
 
+        [DataMember]
         public readonly float y;
 
         public static readonly TextAlignVertical top = new TextAlignVertical(y: -1.0f);

--- a/com.unity.uiwidgets/Runtime/painting/borders.cs
+++ b/com.unity.uiwidgets/Runtime/painting/borders.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Linq;
 using Unity.UIWidgets.external;
 using Unity.UIWidgets.foundation;
@@ -10,11 +11,15 @@ using Color = Unity.UIWidgets.ui.Color;
 using Rect = Unity.UIWidgets.ui.Rect;
 
 namespace Unity.UIWidgets.painting {
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public enum BorderStyle {
+        [EnumMember]
         none,
+        [EnumMember]
         solid,
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public class BorderSide : IEquatable<BorderSide> {
         public BorderSide(
             Color color = null,
@@ -54,8 +59,13 @@ namespace Unity.UIWidgets.painting {
             );
         }
 
+        [DataMember]
         public readonly Color color;
+
+        [DataMember]
         public readonly float width;
+
+        [DataMember]
         public readonly BorderStyle style;
 
         public static readonly BorderSide none = new BorderSide(width: 0.0f, style: BorderStyle.none);
@@ -212,6 +222,7 @@ namespace Unity.UIWidgets.painting {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public abstract class ShapeBorder {
         protected ShapeBorder() {
         }

--- a/com.unity.uiwidgets/Runtime/painting/box_border.cs
+++ b/com.unity.uiwidgets/Runtime/painting/box_border.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Linq;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.painting;
@@ -11,7 +12,7 @@ namespace Unity.UIWidgets.painting {
         circle,
     }
 
-
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public abstract class BoxBorder : ShapeBorder {
         public BoxBorder() {
             isUniform = false;
@@ -147,7 +148,7 @@ namespace Unity.UIWidgets.painting {
         }
     }
 
-
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public class Border : BoxBorder, IEquatable<Border> {
         public Border(
             BorderSide top = null,
@@ -200,9 +201,16 @@ namespace Unity.UIWidgets.painting {
             );
         }
 
+        [DataMember]
         public readonly BorderSide top;
+
+        [DataMember]
         public readonly BorderSide right;
+
+        [DataMember]
         public readonly BorderSide bottom;
+
+        [DataMember]
         public readonly BorderSide left;
 
         public override EdgeInsetsGeometry dimensions {

--- a/com.unity.uiwidgets/Runtime/painting/box_decoration.cs
+++ b/com.unity.uiwidgets/Runtime/painting/box_decoration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.ui;
 using UnityEngine;
@@ -8,6 +9,7 @@ using Color = Unity.UIWidgets.ui.Color;
 using Rect = Unity.UIWidgets.ui.Rect;
 
 namespace Unity.UIWidgets.painting {
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public class BoxDecoration : Decoration, IEquatable<BoxDecoration> {
         public BoxDecoration(
             Color color = null,
@@ -62,13 +64,28 @@ namespace Unity.UIWidgets.painting {
             return base.debugAssertIsValid();
         }
 
+        [DataMember]
         public readonly Color color;
+
+        [DataMember]
         public readonly DecorationImage image;
+
+        [DataMember]
         public readonly Border border;
+
+        [DataMember]
         public readonly BorderRadius borderRadius;
+
+        [DataMember]
         public readonly List<BoxShadow> boxShadow;
+
+        [DataMember]
         public readonly Gradient gradient;
+
+        [DataMember]
         public readonly BlendMode? backgroundBlendMode;
+
+        [DataMember]
         public readonly BoxShape shape;
 
         public override EdgeInsetsGeometry padding {

--- a/com.unity.uiwidgets/Runtime/painting/box_fit.cs
+++ b/com.unity.uiwidgets/Runtime/painting/box_fit.cs
@@ -1,15 +1,24 @@
 using System;
+using System.Runtime.Serialization;
 using Unity.UIWidgets.ui;
 using UnityEngine;
 
 namespace Unity.UIWidgets.painting {
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public enum BoxFit {
+        [EnumMember]
         fill,
+        [EnumMember]
         contain,
+        [EnumMember]
         cover,
+        [EnumMember]
         fitWidth,
+        [EnumMember]
         fitHeight,
+        [EnumMember]
         none,
+        [EnumMember]
         scaleDown,
     }
 

--- a/com.unity.uiwidgets/Runtime/painting/box_shadow.cs
+++ b/com.unity.uiwidgets/Runtime/painting/box_shadow.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Unity.UIWidgets.ui;
 using UnityEngine;
 using Color = Unity.UIWidgets.ui.Color;
 
 namespace Unity.UIWidgets.painting {
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public class BoxShadow : IEquatable<BoxShadow> {
         public BoxShadow(
             Color color = null,
@@ -18,9 +20,16 @@ namespace Unity.UIWidgets.painting {
             this.spreadRadius = spreadRadius;
         }
 
+        [DataMember]
         public readonly Color color;
+
+        [DataMember]
         public readonly Offset offset;
+
+        [DataMember]
         public readonly float blurRadius;
+
+        [DataMember]
         public readonly float spreadRadius;
 
         public static float convertRadiusToSigma(float radius) {

--- a/com.unity.uiwidgets/Runtime/painting/decoration.cs
+++ b/com.unity.uiwidgets/Runtime/painting/decoration.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Runtime.Serialization;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.ui;
 
 namespace Unity.UIWidgets.painting {
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public abstract class Decoration : Diagnosticable {
         protected Decoration() {
         }

--- a/com.unity.uiwidgets/Runtime/painting/decoration_image.cs
+++ b/com.unity.uiwidgets/Runtime/painting/decoration_image.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.ui;
 using UnityEngine;
@@ -7,13 +8,19 @@ using Canvas = Unity.UIWidgets.ui.Canvas;
 using Rect = Unity.UIWidgets.ui.Rect;
 
 namespace Unity.UIWidgets.painting {
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public enum ImageRepeat {
+        [EnumMember]
         repeat,
+        [EnumMember]
         repeatX,
+        [EnumMember]
         repeatY,
+        [EnumMember]
         noRepeat,
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public class DecorationImage : IEquatable<DecorationImage> {
         public DecorationImage(
             ImageProvider image = null,
@@ -36,13 +43,28 @@ namespace Unity.UIWidgets.painting {
             this.matchTextDirection = matchTextDirection;
         }
 
+        [DataMember]
         public readonly ImageProvider image;
+
+        // HDC_TODO: do we need to serialize a listener?
         public readonly ImageErrorListener onError;
+
+        [DataMember]
         public readonly ColorFilter colorFilter;
+
+        [DataMember]
         public readonly BoxFit? fit;
+
+        [DataMember]
         public readonly AlignmentGeometry alignment;
+
+        [DataMember]
         public readonly Rect centerSlice;
+
+        [DataMember]
         public readonly ImageRepeat repeat;
+
+        [DataMember]
         public readonly bool matchTextDirection;
 
         public DecorationImagePainter createPainter(VoidCallback onChanged) {

--- a/com.unity.uiwidgets/Runtime/painting/edge_insets.cs
+++ b/com.unity.uiwidgets/Runtime/painting/edge_insets.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.ui;
@@ -6,6 +7,7 @@ using UnityEngine;
 using Rect = Unity.UIWidgets.ui.Rect;
 
 namespace Unity.UIWidgets.painting {
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public abstract class EdgeInsetsGeometry {
         internal float _bottom { get; }
         internal float _end { get; }
@@ -564,7 +566,7 @@ namespace Unity.UIWidgets.painting {
         }
     }
 
-
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public class EdgeInsets : EdgeInsetsGeometry {
         EdgeInsets(float left, float top, float right, float bottom) {
             this.left = left;
@@ -573,9 +575,16 @@ namespace Unity.UIWidgets.painting {
             this.bottom = bottom;
         }
 
+        [DataMember]
         public readonly float left;
+
+        [DataMember]
         public readonly float right;
+
+        [DataMember]
         public readonly float top;
+
+        [DataMember]
         public readonly float bottom;
 
         public static EdgeInsets infinity = fromLTRB(

--- a/com.unity.uiwidgets/Runtime/painting/gradient.cs
+++ b/com.unity.uiwidgets/Runtime/painting/gradient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Unity.UIWidgets.animation;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.external;
@@ -64,6 +65,7 @@ namespace Unity.UIWidgets.painting {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public abstract class GradientTransform {
         public GradientTransform() {
         }
@@ -71,11 +73,13 @@ namespace Unity.UIWidgets.painting {
         public abstract Matrix4 transform(Rect bounds, TextDirection? textDirection = null);
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public class GradientRotation : GradientTransform {
         public GradientRotation(float radians) {
             this.radians = radians;
         }
 
+        [DataMember]
         public readonly float radians;
 
         public override
@@ -95,6 +99,7 @@ namespace Unity.UIWidgets.painting {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public abstract class Gradient {
         public Gradient(
             List<Color> colors = null,
@@ -107,10 +112,13 @@ namespace Unity.UIWidgets.painting {
             this.transform = transform;
         }
 
+        [DataMember]
         public readonly List<Color> colors;
 
+        [DataMember]
         public readonly List<float> stops;
 
+        [DataMember]
         public readonly GradientTransform transform;
 
         protected List<float> _impliedStops() {

--- a/com.unity.uiwidgets/Runtime/painting/text_style.cs
+++ b/com.unity.uiwidgets/Runtime/painting/text_style.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Linq;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.ui;
 
 namespace Unity.UIWidgets.painting {
+    [DataContract(Namespace = "Unity.UIWidgets.painting")]
     public class TextStyle : Diagnosticable, IEquatable<TextStyle> {
         const string _kDefaultDebugLabel = "unknown";
 
@@ -16,25 +18,45 @@ namespace Unity.UIWidgets.painting {
 
         public static readonly float _defaultFontSize = 14.0f;
 
+        [DataMember]
         public readonly Paint background;
+        [DataMember]
         public readonly Color backgroundColor;
+        [DataMember]
         public readonly Color color;
+        [DataMember]
         public readonly string debugLabel;
+        [DataMember]
         public readonly TextDecoration decoration;
+        [DataMember]
         public readonly Color decorationColor;
+        [DataMember]
         public readonly TextDecorationStyle? decorationStyle;
+        [DataMember]
         public readonly float? decorationThickness;
+        [DataMember]
         public readonly string fontFamily;
+        [DataMember]
         public readonly List<FontFeature> fontFeatures;
+        [DataMember]
         public readonly float? fontSize;
+        [DataMember]
         public readonly FontStyle? fontStyle;
+        [DataMember]
         public readonly FontWeight fontWeight;
+        [DataMember]
         public readonly Paint foreground;
+        [DataMember]
         public readonly float? height;
+        [DataMember]
         public readonly bool inherit;
+        [DataMember]
         public readonly float? letterSpacing;
+        [DataMember]
         public readonly List<BoxShadow> shadows;
+        [DataMember]
         public readonly TextBaseline? textBaseline;
+        [DataMember]
         public readonly float? wordSpacing;
 
         public TextStyle(bool inherit = true,

--- a/com.unity.uiwidgets/Runtime/rendering/box.cs
+++ b/com.unity.uiwidgets/Runtime/rendering/box.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.gestures;
@@ -22,6 +23,7 @@ namespace Unity.UIWidgets.rendering {
         internal readonly bool _canBeUsedByParent;
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.rendering")]
     public class BoxConstraints : Constraints, IEquatable<BoxConstraints> {
         public BoxConstraints(
             float minWidth = 0.0f,
@@ -34,9 +36,16 @@ namespace Unity.UIWidgets.rendering {
             this.maxHeight = maxHeight;
         }
 
+        [DataMember]
         public readonly float minWidth;
+
+        [DataMember]
         public readonly float maxWidth;
+
+        [DataMember]
         public readonly float minHeight;
+
+        [DataMember]
         public readonly float maxHeight;
 
         public static BoxConstraints tight(Size size) {

--- a/com.unity.uiwidgets/Runtime/rendering/object.cs
+++ b/com.unity.uiwidgets/Runtime/rendering/object.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Diagnostics;
 using Unity.UIWidgets.animation;
 using Unity.UIWidgets.foundation;
@@ -378,6 +379,7 @@ namespace Unity.UIWidgets.rendering {
         
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.rendering")]
     public abstract class Constraints {
         
         protected Constraints(){}

--- a/com.unity.uiwidgets/Runtime/rendering/paragraph.cs
+++ b/com.unity.uiwidgets/Runtime/rendering/paragraph.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.gestures;
 using Unity.UIWidgets.painting;
@@ -12,10 +13,15 @@ using Rect = Unity.UIWidgets.ui.Rect;
 using StrutStyle = Unity.UIWidgets.painting.StrutStyle;
 
 namespace Unity.UIWidgets.rendering {
+    [DataContract(Namespace = "Unity.UIWidgets.rendering")]
     public enum TextOverflow {
+        [EnumMember]
         clip,
+        [EnumMember]
         fade,
+        [EnumMember]
         ellipsis,
+        [EnumMember]
         visible
     }
 

--- a/com.unity.uiwidgets/Runtime/rendering/stack.cs
+++ b/com.unity.uiwidgets/Runtime/rendering/stack.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.gestures;
 using Unity.UIWidgets.painting;
@@ -213,14 +214,21 @@ namespace Unity.UIWidgets.rendering {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.rendering")]
     public enum StackFit {
+        [EnumMember]
         loose,
+        [EnumMember]
         expand,
+        [EnumMember]
         passthrough,
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.rendering")]
     public enum Overflow {
+        [EnumMember]
         visible,
+        [EnumMember]
         clip,
     }
 

--- a/com.unity.uiwidgets/Runtime/ui/geometry.cs
+++ b/com.unity.uiwidgets/Runtime/ui/geometry.cs
@@ -514,6 +514,7 @@ namespace Unity.UIWidgets.ui{
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public class Rect : IEquatable<Rect> {
         Rect(float left, float top, float right, float bottom) {
             this.left = left;
@@ -553,9 +554,16 @@ namespace Unity.UIWidgets.ui{
 
         internal float[] _value32 => new[] {left, top, right, bottom};
 
+        [DataMember]
         public readonly float left;
+
+        [DataMember]
         public readonly float top;
+
+        [DataMember]
         public readonly float right;
+
+        [DataMember]
         public readonly float bottom;
 
         public float width {

--- a/com.unity.uiwidgets/Runtime/ui/geometry.cs
+++ b/com.unity.uiwidgets/Runtime/ui/geometry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using UnityEngine;
 
 namespace Unity.UIWidgets.ui{
@@ -140,14 +141,17 @@ namespace Unity.UIWidgets.ui{
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public abstract class OffsetBase : IEquatable<OffsetBase> {
         protected OffsetBase(float _dx, float _dy) {
             this._dx = _dx;
             this._dy = _dy;
         }
 
+        [DataMember]
         protected readonly float _dx;
 
+        [DataMember]
         protected readonly float _dy;
 
         public bool isInfinite {
@@ -221,6 +225,7 @@ namespace Unity.UIWidgets.ui{
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public class Offset : OffsetBase, IEquatable<Offset> {
         public Offset(float dx, float dy) : base(dx, dy) {
         }

--- a/com.unity.uiwidgets/Runtime/ui/painting.cs
+++ b/com.unity.uiwidgets/Runtime/ui/painting.cs
@@ -337,39 +337,69 @@ namespace Unity.UIWidgets.ui {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public enum BlendMode {
+        [EnumMember]
         clear,
+        [EnumMember]
         src,
+        [EnumMember]
         dst,
+        [EnumMember]
         srcOver,
+        [EnumMember]
         dstOver,
+        [EnumMember]
         srcIn,
+        [EnumMember]
         dstIn,
+        [EnumMember]
         srcOut,
+        [EnumMember]
         dstOut,
+        [EnumMember]
         srcATop,
+        [EnumMember]
         dstATop,
+        [EnumMember]
         xor,
+        [EnumMember]
         plus,
 
         // REF: https://www.w3.org/TR/compositing-1/#blendingseparable
+        [EnumMember]
         modulate,
+        [EnumMember]
         screen,
+        [EnumMember]
         overlay,
+        [EnumMember]
         darken,
+        [EnumMember]
         lighten,
+        [EnumMember]
         colorDodge,
+        [EnumMember]
         colorBurn,
+        [EnumMember]
         hardLight,
+        [EnumMember]
         softLight,
+        [EnumMember]
         difference,
+        [EnumMember]
         exclusion,
+        [EnumMember]
         multiply,
 
         // REF: https://www.w3.org/TR/compositing-1/#blendingnonseparable
+        [EnumMember]
         hue,
+        [EnumMember]
         saturation,
+        [EnumMember]
         color,
+        [EnumMember]
         luminosity,
     }
 
@@ -1657,6 +1687,7 @@ namespace Unity.UIWidgets.ui {
         static extern bool PathMeasure_nativeNextContour();
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public class ColorFilter : IEquatable<ColorFilter> {
         ColorFilter(Color color, BlendMode? blendMode, float[] matrix, int type) {
             _color = color;
@@ -1681,9 +1712,16 @@ namespace Unity.UIWidgets.ui {
             return new ColorFilter(null, null, null, _TypeSrgbToLinearGamma);
         }
 
+        [DataMember]
         internal readonly Color _color;
+
+        [DataMember]
         internal readonly BlendMode? _blendMode;
+
+        [DataMember]
         internal readonly float[] _matrix;
+
+        [DataMember]
         internal readonly int _type;
 
         internal const int _TypeMode = 1; // MakeModeFilter

--- a/com.unity.uiwidgets/Runtime/ui/painting.cs
+++ b/com.unity.uiwidgets/Runtime/ui/painting.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 using System.Text;
 using AOT;
 using Unity.UIWidgets.animation;
@@ -149,6 +150,7 @@ namespace Unity.UIWidgets.ui {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public class Color : IEquatable<Color> {
         public Color(uint value) {
             this.value = value & 0xFFFFFFFF;
@@ -176,6 +178,7 @@ namespace Unity.UIWidgets.ui {
                         (b & 0xff)));
         }
 
+        [DataMember]
         public uint value;
 
         public int alpha {
@@ -405,6 +408,7 @@ namespace Unity.UIWidgets.ui {
         internal const int _kDoNotResizeDimension = -1;
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public class Paint {
         internal readonly byte[] _data = new byte[_kDataByteCount];
 

--- a/com.unity.uiwidgets/Runtime/ui/text.cs
+++ b/com.unity.uiwidgets/Runtime/ui/text.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 using AOT;
 using Unity.UIWidgets.async;
 using Unity.UIWidgets.foundation;
@@ -9,12 +10,15 @@ using Unity.UIWidgets.services;
 using UnityEngine;
 
 namespace Unity.UIWidgets.ui {
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public enum FontStyle {
+        [EnumMember]
         normal,
-
+        [EnumMember]
         italic
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public class FontWeight {
         public static readonly FontWeight w100 = new FontWeight(0);
 
@@ -54,6 +58,7 @@ namespace Unity.UIWidgets.ui {
             {8, "FontWeight.w900"}
         };
 
+        [DataMember]
         public readonly int index;
 
         public FontWeight(int index) {
@@ -75,11 +80,14 @@ namespace Unity.UIWidgets.ui {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public class FontFeature : IEquatable<FontFeature> {
         internal static readonly int _kEncodedSize = 8;
 
+        [DataMember]
         public readonly string feature;
 
+        [DataMember]
         public readonly int value;
 
         public FontFeature(string feature, int value = 1) {
@@ -183,26 +191,31 @@ namespace Unity.UIWidgets.ui {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public enum TextAlign {
+        [EnumMember]
         left,
-
+        [EnumMember]
         right,
-
+        [EnumMember]
         center,
-
+        [EnumMember]
         justify,
-
+        [EnumMember]
         start,
-
+        [EnumMember]
         end
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public enum TextBaseline {
+        [EnumMember]
         alphabetic,
-
+        [EnumMember]
         ideographic
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public class TextDecoration : IEquatable<TextDecoration> {
         public static readonly TextDecoration none = new TextDecoration(0x0);
 
@@ -212,6 +225,7 @@ namespace Unity.UIWidgets.ui {
 
         public static readonly TextDecoration lineThrough = new TextDecoration(0x4);
 
+        [DataMember]
         internal readonly int _mask;
 
         public TextDecoration(int _mask) {
@@ -1108,8 +1122,11 @@ namespace Unity.UIWidgets.ui {
         }
     }
 
+    [DataContract(Namespace = "Unity.UIWidgets.ui")]
     public enum TextDirection {
+        [EnumMember]
         rtl,
+        [EnumMember]
         ltr,
     }
 


### PR DESCRIPTION
The change is required for the IDE to properly serialize/de-serialize its widget tree.

I will include this submodule hash in the IDE pull request which implements the XML serialization using `DataContractSerializer`.