### PR TITLE
Fix TextInputAction for desktop

### DIFF
--- a/com.unity.uiwidgets/Runtime/services/keyboard.cs
+++ b/com.unity.uiwidgets/Runtime/services/keyboard.cs
@@ -67,6 +67,8 @@ namespace Unity.UIWidgets.service {
 
         TextEditingValue _value;
 
+        TextInputConfiguration _textInputConfiguration;
+
         public void show() {
         }
 
@@ -108,10 +110,12 @@ namespace Unity.UIWidgets.service {
 
         public void setClient(int client, TextInputConfiguration configuration) {
             _client = client;
+            _textInputConfiguration = configuration;
         }
 
         public void clearClient() {
             _client = 0;
+            _textInputConfiguration = null;
         }
 
         public bool imeRequired() {
@@ -161,7 +165,8 @@ namespace Unity.UIWidgets.service {
                         }
 
                         if (ch == '\n') {
-                            Timer.create(TimeSpan.Zero, () => { TextInput._performAction(_client, TextInputAction.newline); });
+                            Timer.create(TimeSpan.Zero, () => { TextInput._performAction(_client, 
+                                _textInputConfiguration?.inputAction ?? TextInputAction.newline); });
                         }
 
                         if (_validateCharacter(ch)) {


### PR DESCRIPTION
This PR aims to implement the TextInputAction feature for desktop.

Generally this is originally part of a mobile-device-specific feature (i.e., `TextInputConfiguration`) which is used to define the appearance and functionality of a virtual keyboard. Specifically, the `TextInputAction` will controls how the "return button" of the keyboard looks like and what signal it emits when pressed (e.g., add a newline? finish the edit? open a search window?)

On desktop, although we don't have a virtual keyboard, the `TextInputAction` may still affects how we process the keyboard events. Specifically, since the physical "return button" plays the exact role of the "return button" on a virtual keyboard, we should also emit different signals when it is pressed according to the current `TextInputConfiguration`. In this PR, we implement this feature.

For detailed descriptions on this feature, please go to: https://api.flutter.dev/flutter/services/TextInputAction-class.html