### PR TITLE
enable wantsMouseMove events on editorWindow

### DIFF
--- a/com.unity.uiwidgets/Editor/UIWidgetsEditorPanel.cs
+++ b/com.unity.uiwidgets/Editor/UIWidgetsEditorPanel.cs
@@ -41,6 +41,11 @@ namespace Unity.UIWidgets.Editor {
 
         void OnEnable() {
             D.assert(_wrapper == null);
+
+            //enable listener to MouseMoveEvents by default
+            //user can disable it in onEnable() if needed
+            wantsMouseMove = true;
+            
             _configurations = new Configurations();
             _wrapper = new UIWidgetsPanelWrapper();
             onEnable();


### PR DESCRIPTION
This PR enables the UIWidgetsEditorWindow to listen to `MouseMoveEvent` by setting `wantsMouseMove` to true by default.

`wantsMouseMove` is a newly introduced feature of latest Unity (e.g., 2020 versions) which controls whether a EditorWindow should listener to `MouseMoveEvent`. It is turned off by default for performance. But in UIWidgets we need it on so that features like mouse hover can be properly supported.

User can still disable this in the `onEnable()` function when needed