### PR TITLE
[WIP] Try to make the build engine scripts compatible with MacOS 12 SDKs

### DIFF
--- a/engine/Scripts/patches/find_sdk.patch
+++ b/engine/Scripts/patches/find_sdk.patch
@@ -7,7 +7,7 @@ index 0534766..e503ced 100755
    else:
      sdk_dir = os.path.join(out.rstrip(), 'SDKs')
 -  sdks = [re.findall('^MacOSX(10\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
-+  sdks = [re.findall('^MacOSX(1[0-1]\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
++  sdks = [re.findall('^MacOSX(1[0-2]\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
    sdks = [s[0] for s in sdks if s]  # [['10.5'], ['10.6']] => ['10.5', '10.6']
    sdks = [s for s in sdks  # ['10.5', '10.6'] => ['10.6']
            if parse_version(s) >= parse_version(min_sdk_version)]


### PR DESCRIPTION
This PR aims to fix the issue that after upgrading MacOS and XCode to the latest (i.e., MacOS 12 and IOS 15) the flutter engine cannot be correctly built.

The main reason is two-fold: (1) there are conflicts between the old-versioned header files in the buildtools and MacOS 12 SDK; (2) there are some breaking changes in the new MacOS SDK (e.g., this [issue](https://discuss.kotlinlang.org/t/library-from-swift-cinterop-doesnt-compile-with-xcode-13/23021)) that are not compatible with the codes in flutter 1.17.5

This PR is still in progress now since I haven't figured out a way to fix (2) yet. Since the root cause is that, flutter 1.17.5 is old enough that it may indeed be not compatible with the latest SDKs, maybe a complete solution is to either upgrade our flutter engine or downgrade MacOS and IOS SDK versions (MacOS to 11.0 should work, IOS issue has not been touched yet).

In this PR I also refined the build scripts in build.py a little so it can address the `flutter_root_path` configuration better