### PR TITLE
Fix Lottie crash during wrong path

### DIFF
--- a/com.unity.uiwidgets/Runtime/Plugins/Android/libUIWidgets.so
+++ b/com.unity.uiwidgets/Runtime/Plugins/Android/libUIWidgets.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65a6663fd0c92155fed6869a2902e486f27593d836c93a769ea137a0d4c068a5
-size 76739172
+oid sha256:6538e29dcefa8b013fd46288f17fbd95a14e6e2ae73ca15c67acc2ec25565e35
+size 76134220

--- a/com.unity.uiwidgets/Runtime/Plugins/osx/libUIWidgets.dylib
+++ b/com.unity.uiwidgets/Runtime/Plugins/osx/libUIWidgets.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d1de13043564e2f2b384ec3aefe1e500e42281b9d67cebca131c54ae841a0c37
-size 21804000
+oid sha256:99313d899e6946d4d614c2a0a5cacc050cc7ff0bd480c19428435363633169a8
+size 21801256

--- a/com.unity.uiwidgets/Runtime/Plugins/x86_64/libUIWidgets.dll
+++ b/com.unity.uiwidgets/Runtime/Plugins/x86_64/libUIWidgets.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52dda23bf8cccf4e80dd4851bafe11bffae6beec925b1112ffa17cdbf13637e5
+oid sha256:74a8add2eb68589ffdde29bf411e53530415b618aaeee9a55fce80ad937aa4d9
 size 11260928

--- a/com.unity.uiwidgets/Runtime/ui/painting.cs
+++ b/com.unity.uiwidgets/Runtime/ui/painting.cs
@@ -3101,7 +3101,7 @@ namespace Unity.UIWidgets.ui {
         public Skottie(string path) {
             var Id = Skottie_Construct(path);
             if(Id == IntPtr.Zero){
-                Debug.LogError($"cannot load lottie from {path}, please check file exist and valid");
+                Debug.Log($"cannot load lottie from {path}, please check file exist and valid");
             }else {
                 _setPtr(Id);
             }

--- a/com.unity.uiwidgets/Runtime/ui/painting.cs
+++ b/com.unity.uiwidgets/Runtime/ui/painting.cs
@@ -3099,7 +3099,12 @@ namespace Unity.UIWidgets.ui {
     
     public class Skottie : NativeWrapper {
         public Skottie(string path) {
-            _setPtr(Skottie_Construct(path));
+            var Id = Skottie_Construct(path);
+            if(Id == IntPtr.Zero){
+                Debug.LogError($"cannot load lottie from {path}, please check file exist and valid");
+            }else {
+                _setPtr(Id);
+            }
         }
 
         public override void DisposePtr(IntPtr ptr) {

--- a/engine/src/lib/ui/painting/skottie.cc
+++ b/engine/src/lib/ui/painting/skottie.cc
@@ -14,6 +14,9 @@ fml::RefPtr<Skottie> Skottie::Create(char* path) {
   path = (char*)fileOut;
 #endif
   sk_sp<skottie::Animation> animation_ = skottie::Animation::MakeFromFile(path);
+  if(animation_ == nullptr){
+    return nullptr;
+  }
   return fml::MakeRefCounted<Skottie>(animation_);
 }
 
@@ -32,19 +35,34 @@ float Skottie::duration() { return animation_->duration(); }
 UIWIDGETS_API(Skottie*)
 Skottie_Construct(char* path) {
   fml::RefPtr<Skottie> skottie = Skottie::Create(path);
+  if(skottie.get() == nullptr){
+    return nullptr;
+  }
   skottie->AddRef();
   return skottie.get();
 }
 
 UIWIDGETS_API(void)
-Skottie_Dispose(Skottie* ptr) { ptr->Release(); }
+Skottie_Dispose(Skottie* ptr) {
+  if(ptr == nullptr){
+      return;
+  }
+  ptr->Release();
+}
 
 UIWIDGETS_API(void)
 Skottie_Paint(Skottie* ptr, Canvas* canvas, float x, float y, float width,
               float height, float frame) {
+  if(ptr == nullptr){
+      return;
+  }
   ptr->paint(canvas, x, y, width, height, frame);
 }
 
 UIWIDGETS_API(float)
-Skottie_Duration(Skottie* ptr) { return ptr->duration(); }
+Skottie_Duration(Skottie* ptr) {
+  if(ptr == nullptr){
+      return 0;
+  }
+  return ptr->duration(); }
 }  // namespace uiwidgets


### PR DESCRIPTION
When Lottie get a path, which does not contain valid lottie json, c++ crashes. 

Fixed by checking null.