### PR TITLE
fix input issue

### DIFF
--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanel.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanel.cs
@@ -446,6 +446,8 @@ namespace Unity.UIWidgets.engine {
 
         UIWidgetsInputMode _inputMode;
 
+        static UIWidgetsPanel _currentActivePanel = null;
+
         void _convertPointerData(PointerEventData evt, out Vector2? position, out int pointerId) {
             position = _inputMode == UIWidgetsInputMode.Mouse
                 ? _getPointerPosition(Input.mousePosition)
@@ -484,9 +486,11 @@ namespace Unity.UIWidgets.engine {
 
         void Input_OnEnable() {
             _inputMode = Input.mousePresent ? UIWidgetsInputMode.Mouse : UIWidgetsInputMode.Touch;
+            Focus();
         }
 
         void Input_OnDisable() {
+            UnFocus();
         }
 
         void Input_Update() {
@@ -519,7 +523,23 @@ namespace Unity.UIWidgets.engine {
 #endif
         }
 
+        private bool isActivePanel => _currentActivePanel == this;
+
+        public void Focus() {
+            _currentActivePanel = this;
+        }
+
+        public void UnFocus() {
+            if (_currentActivePanel == this) {
+                _currentActivePanel = null;
+            }
+        }
+
         void Input_OnGUI() {
+            if (!isActivePanel) {
+                return;
+            }
+            
             var e = Event.current;
             if (e.isKey) {
                 _wrapper.OnKeyDown(e: e);
@@ -561,6 +581,7 @@ namespace Unity.UIWidgets.engine {
         }
 
         public void OnPointerDown(PointerEventData eventData) {
+            Focus();
             _convertPointerData(eventData, out var pos, out var pointerId);
             _wrapper.OnPointerDown(pos, pointerId);
         }
@@ -571,6 +592,7 @@ namespace Unity.UIWidgets.engine {
         }
 
         public void OnDrag(PointerEventData eventData) {
+            Focus();
             _convertPointerData(eventData, out var pos, out var pointerId);
             _wrapper.OnDrag(pos, pointerId);
         }


### PR DESCRIPTION
In this PR we aims to fix the issue #304 , in which:
(1) we introduced a new concept of "Focus", which is used to indicate that which UIWidgetsPanel is currently active and able to accept keyboard events. At any time, there is only one UIWidgetsPanel that is "Focused"

(2) when a UIWidgetsPanel is created, the currently "Focused" panel will become this panel. If there are multiple UIWidgetsPanels and the user is clicking/dragging on one panel, this panel will also be made the currently "Focused" panel

(3)  if a UIWidgetsPanel is destroyed and it is currently "Focused“, then no UIWidgetsPanel will be marked "Focused"

(4) Developers can also use the exposed API: `Focus `and `UnFocus `to implement your own customized logics