### PR TITLE
refine external texture management

### DIFF
--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsExternalTextureRegistry.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsExternalTextureRegistry.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using UnityEngine;
+using Unity.UIWidgets.foundation;
 
 namespace Unity.UIWidgets.engine {
     public partial class UIWidgetsPanelWrapper {
@@ -29,18 +29,17 @@ namespace Unity.UIWidgets.engine {
             foreach(var texturePair in externalTextures) {
                 var curInternalTextureId = texturePair.Value;
                 if (curInternalTextureId == internalTextureId) {
-                    if (externalTexturePtr != IntPtr.Zero) {
-                        Debug.LogError($"The internal texture id {internalTextureId} is shared by different external textures {externalTexturePtr} amd {curInternalTextureId}");
-                        return;
-                    }
+                    D.assert(externalTexturePtr == IntPtr.Zero, () => $"The internal texture id {internalTextureId} is shared by different external textures {externalTexturePtr} and {curInternalTextureId}");
                     externalTexturePtr = texturePair.Key;
                 }
             }
-
-            ReleaseExternalTexture(externalTexturePtr);
+            if (externalTexturePtr != IntPtr.Zero) {
+                ReleaseExternalTexture(externalTexturePtr);
+            }
         }
 
         public int RegisterExternalTexture(IntPtr externalTexturePtr) {
+            D.assert(externalTexturePtr != IntPtr.Zero, () => "Cannot register null external texture");
             if (!externalTextures.ContainsKey(externalTexturePtr)) {
                 var internalTextureId = registerTexture(externalTexturePtr);
                 externalTextures[externalTexturePtr] = internalTextureId;

--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsExternalTextureRegistry.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsExternalTextureRegistry.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Unity.UIWidgets.engine {
+    public partial class UIWidgetsPanelWrapper {
+        readonly Dictionary<IntPtr, int> externalTextures = new Dictionary<IntPtr, int>();
+
+        void ReleaseExternalTextures() {
+            foreach(var texturePair in externalTextures) {
+                var internalTextureId = texturePair.Value;
+                unregisterTexture(internalTextureId);
+            }
+            
+            externalTextures.Clear();
+        }
+
+        void ReleaseExternalTexture(IntPtr externalTexturePtr) {
+            if (externalTextures.ContainsKey(externalTexturePtr)) {
+                var internalTextureId = externalTextures[externalTexturePtr];
+                unregisterTexture(internalTextureId);
+
+                externalTextures.Remove(externalTexturePtr);
+            }
+        }
+        
+        public void ReleaseExternalTexture(int internalTextureId) {
+            var externalTexturePtr = IntPtr.Zero;
+            foreach(var texturePair in externalTextures) {
+                var curInternalTextureId = texturePair.Value;
+                if (curInternalTextureId == internalTextureId) {
+                    if (externalTexturePtr != IntPtr.Zero) {
+                        Debug.LogError($"The internal texture id {internalTextureId} is shared by different external textures {externalTexturePtr} amd {curInternalTextureId}");
+                        return;
+                    }
+                    externalTexturePtr = texturePair.Key;
+                }
+            }
+
+            ReleaseExternalTexture(externalTexturePtr);
+        }
+
+        public int RegisterExternalTexture(IntPtr externalTexturePtr) {
+            if (!externalTextures.ContainsKey(externalTexturePtr)) {
+                var internalTextureId = registerTexture(externalTexturePtr);
+                externalTextures[externalTexturePtr] = internalTextureId;
+            }
+            
+            return externalTextures[externalTexturePtr];
+        }
+    }
+}

--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsExternalTextureRegistry.cs.meta
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsExternalTextureRegistry.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 226ec8e5a3d745bc854a511f3bc7ba39
+timeCreated: 1646625771

--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanelWrapper.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanelWrapper.cs
@@ -202,6 +202,8 @@ public partial class UIWidgetsPanelWrapper {
         }
         public void Destroy() {
             if (_ptr != IntPtr.Zero) {
+                ReleaseExternalTextures();
+
                 UIWidgetsPanel_onDisable(ptr: _ptr);
                 UIWidgetsPanel_dispose(ptr: _ptr);
                 _ptr = IntPtr.Zero;
@@ -209,7 +211,7 @@ public partial class UIWidgetsPanelWrapper {
 
             _handle.Free();
             _handle = default;
-
+            
             _disableUIWidgetsPanel();
             D.assert(result: !isolate.isValid);
         }
@@ -231,8 +233,8 @@ public partial class UIWidgetsPanelWrapper {
             return true;
         }
 
-        public int registerTexture(Texture texture) {
-            return UIWidgetsPanel_registerTexture(ptr: _ptr, texture.GetNativeTexturePtr());
+        public int registerTexture(IntPtr externalTexturePtr) {
+            return UIWidgetsPanel_registerTexture(ptr: _ptr, externalTexturePtr);
         }
 
         public void unregisterTexture(int textureId) {

--- a/com.unity.uiwidgets/Runtime/rendering/texture.cs
+++ b/com.unity.uiwidgets/Runtime/rendering/texture.cs
@@ -79,7 +79,7 @@ namespace Unity.UIWidgets.rendering {
                     markNeedsLayout();
                     SchedulerBinding.instance.scheduleFrameCallback(_handleAppFrame);
                     if (_texture.GetNativeTexturePtr() != IntPtr.Zero) {
-                        _textureId = UIWidgetsPanelWrapper.current.registerTexture(_texture);
+                        _textureId = UIWidgetsPanelWrapper.current.RegisterExternalTexture(_texture.GetNativeTexturePtr());
                     }
                 }
                 return;

--- a/com.unity.uiwidgets/Runtime/widgets/texture.cs
+++ b/com.unity.uiwidgets/Runtime/widgets/texture.cs
@@ -13,7 +13,7 @@ namespace Unity.UIWidgets.widgets {
             this.textureId = textureId;
             this.texture = texture;
             if (texture != null && texture.GetNativeTexturePtr() != IntPtr.Zero) {
-                this.textureId = UIWidgetsPanelWrapper.current.registerTexture(texture);
+                this.textureId = UIWidgetsPanelWrapper.current.RegisterExternalTexture(texture.GetNativeTexturePtr());
             }
         }
 


### PR DESCRIPTION
In this PR we try to refine the management of external textures for Texture widgets by adding the functionality of an `ExternalTextureRegistry`  to the UIWidgetsPanelWrapper, including:

(1) cache the (external texture)-(internal texture id) mapping so that an external texture is only registered on the C++ side once
(2) unregister the external textures on the C++ side when the UIWidgets panel is destroyed