### PR TITLE
fix windows external texture id bug

### DIFF
--- a/com.unity.uiwidgets/Runtime/Plugins/x86_64/libUIWidgets.dll
+++ b/com.unity.uiwidgets/Runtime/Plugins/x86_64/libUIWidgets.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbc1c097cfd5748dea7af16ed9a2ef3ecf65a27c390f3c5d8509fa9e2cd4ab9e
+oid sha256:a370631f25afad78a8eb571a94750ec68d8328619e03dfeabf1e24726daad3c7
 size 11260416

--- a/engine/src/shell/platform/unity/windows/uiwidgets_panel.cc
+++ b/engine/src/shell/platform/unity/windows/uiwidgets_panel.cc
@@ -254,7 +254,7 @@ void* UIWidgetsPanel::OnRenderTexture(size_t width,
 bool UIWidgetsPanel::ReleaseNativeRenderTexture() { return surface_manager_->ReleaseNativeRenderTexture(); }
 
 int UIWidgetsPanel::RegisterTexture(void* native_texture_ptr) {
-  int texture_identifier = 0;
+  static int texture_identifier = 0;
   texture_identifier++;
 
   auto* engine = reinterpret_cast<EmbedderEngine*>(engine_);


### PR DESCRIPTION
The external texture id in windows is not properly set, making all external texture shares the same `textureId = 1`. In this PR we fix this issue.