### PR TITLE
add support for absolute image path

### DIFF
--- a/Samples/UIWidgetsSamples_2019_4/Assets/Script/ImageTest.cs
+++ b/Samples/UIWidgetsSamples_2019_4/Assets/Script/ImageTest.cs
@@ -4,6 +4,8 @@ using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.painting;
 using Unity.UIWidgets.ui;
 using Unity.UIWidgets.widgets;
+using UnityEngine;
+using Color = Unity.UIWidgets.ui.Color;
 using Image = Unity.UIWidgets.widgets.Image;
 using ui_ = Unity.UIWidgets.widgets.ui_;
 
@@ -46,8 +48,24 @@ namespace UIWidgetsSample
 
         class ExampleState : State<ExampleApp>
         {
+
+            //user are responsible to get the right absolute image path for different platforms
+            private string getAbsoluteImagePathForApp(string simplePath)
+            {
+                var absolutePath = System.IO.Path.Combine(Application.streamingAssetsPath, simplePath);
+#if UNITY_ANDROID && !UNITY_EDITOR
+                //do nothing
+#else
+                absolutePath = "file://" + absolutePath;
+#endif
+                return absolutePath;
+            }
+            
             public override Widget build(BuildContext context)
             {
+                var imageSimplePath = "test.gif";
+                var absolutePath = getAbsoluteImagePathForApp(imageSimplePath);
+
                 return new Container(
                     child: new Column(
                         children: new List<Widget>
@@ -59,8 +77,9 @@ namespace UIWidgetsSample
                                 decoration: new BoxDecoration(
                                     borderRadius: BorderRadius.all(Radius.circular(8))
                                 ),
-                                child: Image.file("test.gif", gaplessPlayback: true)
+                                child: Image.file(absolutePath, gaplessPlayback: true, isAbsolutePath: true)
                             ),
+                            new Container(width: 50f, height: 50f, child: Image.file(imageSimplePath, gaplessPlayback: true)),
                             new Container(
                                 width: 200,
                                 height: 100,

--- a/com.unity.uiwidgets/Runtime/painting/image_provider.cs
+++ b/com.unity.uiwidgets/Runtime/painting/image_provider.cs
@@ -790,15 +790,32 @@ namespace Unity.UIWidgets.painting {
     }
 
     public class FileImage : ImageProvider<FileImage>, IEquatable<FileImage> {
-        public FileImage(string file, float scale = 1.0f) {
+        public FileImage(string file, float scale = 1.0f, bool isAbsolutePath = false) {
             D.assert(file != null);
             this.file = file;
             this.scale = scale;
+            this.isAbsolutePath = isAbsolutePath;
         }
 
         public readonly string file;
 
         public readonly float scale;
+        
+        //This is a Unity specific parameter we added to FileImage, if you want to change this file (for example, when 
+        //you are going to upgrade UIWidgets to match a new flutter version), please remain this parameter and its 
+        //relevant logics here, which is indeed very simple!
+        //
+        //This parameter represents whether the input parameter "file" is a absolute path or not.
+        //In our original design, we require developers to put all their local image files inside the streamingAssets
+        //folder because Unity won't process them while packing (Instead if an image is put inside the Resources
+        //folder, it will be encoded into platform specific formats by Unity).
+        //This requirement is not always reasonable since developers can also put local files inside other Unity
+        //builtin paths like persistent path, etc.. For this scenario this parameter "isAbsolutePath" is introduced
+        //so that developers are able to set it true to determine the absolute file path themselves.
+        //
+        //But one issue is, if developers decide to use the absolute file path, they have to be responsible to deal with
+        //the platform relevant issues
+        private readonly bool isAbsolutePath;
 
         public override Future<FileImage> obtainKey(ImageConfiguration configuration) {
             return new SynchronousFuture<FileImage>(this);
@@ -815,11 +832,16 @@ namespace Unity.UIWidgets.painting {
         }
 
         Future<Codec> _loadAsync(FileImage key, DecoderCallback decode) {
+            var path = key.file;
+
+            if (!isAbsolutePath) {
 #if UNITY_ANDROID && !UNITY_EDITOR
-            var path = Path.Combine(Application.streamingAssetsPath, key.file);
+                path = Path.Combine(Application.streamingAssetsPath, key.file);
 #else
-            var path = "file://" + Path.Combine(Application.streamingAssetsPath, key.file);
+                path = "file://" + Path.Combine(Application.streamingAssetsPath, key.file);
 #endif
+            }
+
             using(var unpackerWWW = UnityWebRequest.Get(path)) {
                 unpackerWWW.SendWebRequest();
                 while (!unpackerWWW.isDone) {

--- a/com.unity.uiwidgets/Runtime/widgets/image.cs
+++ b/com.unity.uiwidgets/Runtime/widgets/image.cs
@@ -178,6 +178,7 @@ namespace Unity.UIWidgets.widgets {
 
         public static Image file(
             string file,
+            bool isAbsolutePath = false,
             Key key = null,
             float scale = 1.0f,
             ImageFrameBuilder frameBuilder = null,
@@ -197,7 +198,7 @@ namespace Unity.UIWidgets.widgets {
             int? cacheHeight = null
         ) {
             var fileImage = ResizeImage.resizeIfNeeded(cacheWidth: cacheWidth, cacheHeight: cacheHeight,
-                new FileImage(file: file, scale: scale));
+                new FileImage(file: file, scale: scale, isAbsolutePath: isAbsolutePath));
             return new Image(
                 key: key,
                 image: fileImage,


### PR DESCRIPTION
In this PR, we add the support that, users can now load local image from an absolute path as suggested in #314 

In this solution (we might still need to seek for another better solution?), we add an extra parameter `isAbsolutePath` to both`Image.file` and the `ctor` of `FileImage`: If the parameter is true, we won't process the path as we do before (when we assume that all local image file paths are prefixed by the streamingAssets path) and try to load the image from the original path directly.

Note that in this solution, once the user pass in the absolute path of the image, he/she is also responsible to deal with the platform-dependent issues.

We also change the `ImageTest` sample a bit to show a basic use case.