### PR TITLE
fix text input bug

### DIFF
--- a/com.unity.uiwidgets/Runtime/gestures/converter.cs
+++ b/com.unity.uiwidgets/Runtime/gestures/converter.cs
@@ -207,11 +207,8 @@ namespace Unity.UIWidgets.gestures {
                                 keyBoardEvent.command = (datum.modifier & (1 << (int) FunctionKey.command)) > 0;
                                 keyBoardEvent.control = (datum.modifier & (1 << (int) FunctionKey.control)) > 0;
 #endif
-                                //if there is a text input field attached then the input should be swallowed by it. Otherwise we pass the input to RawKeyboard
-                                if (!TextInput.OnGUI()) {
-                                    RawKeyboard.instance._handleKeyEvent(keyBoardEvent);
-                                }
-
+                                TextInput.OnGUI();
+                                RawKeyboard.instance._handleKeyEvent(keyBoardEvent);
                             }
                             break;
                     }

--- a/com.unity.uiwidgets/Runtime/gestures/converter.cs
+++ b/com.unity.uiwidgets/Runtime/gestures/converter.cs
@@ -207,8 +207,11 @@ namespace Unity.UIWidgets.gestures {
                                 keyBoardEvent.command = (datum.modifier & (1 << (int) FunctionKey.command)) > 0;
                                 keyBoardEvent.control = (datum.modifier & (1 << (int) FunctionKey.control)) > 0;
 #endif
-                                RawKeyboard.instance._handleKeyEvent(keyBoardEvent);
-                                TextInput.OnGUI();
+                                //if there is a text input field attached then the input should be swallowed by it. Otherwise we pass the input to RawKeyboard
+                                if (!TextInput.OnGUI()) {
+                                    RawKeyboard.instance._handleKeyEvent(keyBoardEvent);
+                                }
+
                             }
                             break;
                     }

--- a/com.unity.uiwidgets/Runtime/services/text_input.cs
+++ b/com.unity.uiwidgets/Runtime/services/text_input.cs
@@ -749,15 +749,19 @@ namespace Unity.UIWidgets.service {
             }
         }
 
-        internal static void OnGUI() {
+        internal static bool OnGUI() {
             if (_currentConnection != null && _currentConnection._window == Window.instance) {
                 (keyboardDelegate as TextInputOnGUIListener)?.OnGUI();
+
+                return true;
             }
             else {
                 //skip all the key events when no connection is attached
                 while (!PointerEventConverter.KeyEvent.isEmpty()) {
                     PointerEventConverter.KeyEvent.Dequeue();
                 }
+
+                return false;
             }
         }
 

--- a/com.unity.uiwidgets/Runtime/services/text_input.cs
+++ b/com.unity.uiwidgets/Runtime/services/text_input.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Unity.UIWidgets.async;
 using Unity.UIWidgets.external.simplejson;
 using Unity.UIWidgets.foundation;
+using Unity.UIWidgets.gestures;
 using Unity.UIWidgets.services;
 using Unity.UIWidgets.ui;
 using UnityEngine;
@@ -751,6 +752,12 @@ namespace Unity.UIWidgets.service {
         internal static void OnGUI() {
             if (_currentConnection != null && _currentConnection._window == Window.instance) {
                 (keyboardDelegate as TextInputOnGUIListener)?.OnGUI();
+            }
+            else {
+                //skip all the key events when no connection is attached
+                while (!PointerEventConverter.KeyEvent.isEmpty()) {
+                    PointerEventConverter.KeyEvent.Dequeue();
+                }
             }
         }
 


### PR DESCRIPTION
In this PR we aims to fix one bug in text input, including:

(1) **BUG 1:** The way to reproduce the bug is straight-forward: if a user presses keys (e.g., `A`, `B`, `C`) on the keyboard while no editable text is selected, then when he selects an empty editable text and input one letter, (e.g., `D`),  the editable text would become `ABCD` instead of `D`. The root cause is that, when the `DefaultKeyboardDelegate` trying to process the current input (in the method `OnGUI()`), it will iterate all the input events stored in the queue `PointerEventConverter.KeyEvent`. Therefore since all the key events would be stored inside the queue even if there is no editable text available to accept them. Once an editable text is activated and trying to accept the current one key event, all the stored (but out-dated) events will be passed to it by mistake.

To fix this issue, we just skip all the key events when no editable text is attached