### PR TITLE
use new Unity API in 2020.3.37 to create compatible external texture

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -210,7 +210,12 @@ UIWidgets也支持Gif！
 #### 七、图片导入设置
 请将图片放入StreamingAssets下，而后用```Image.file```读取
 
-#### 八、移动设备优化
+#### 八、外接纹理显示
+利用我们新增的Unity内置API``UIWidgetsExternalTextureHelper.createCompatibleExternalTexture``以及UIWidgets中的``Texture``组件，开发者可以生成一个兼容UIWidgets底层的Unity纹理并将它绑定并渲染到UIWidgets页面上。从而可以将3D模型、视频等添加到App中作为一个UI组件。
+
+需要注意，本功能目前只支持**OpenGLCore** (Mac), **OpenGLes** (iOS&Android) 以及 **D3D11** (Windows)，且必须使用**Unity 2020.3.37f1c1**及以上版本。在我们的示例项目中有一个简单的例子 (例如``3DTest1.unity``)可供参考。
+
+#### 九、移动设备优化
 目前在默认情况下，为了保证流畅度，项目在各个平台上均会以最高的刷新频率运行。不过您可以通过在代码中设置```UIWidgetsGlobalConfiguration.EnableAutoAdjustFramerate = true```的方式来开启自动降帧的功能：该功能开启后，在UI内容不变的情况下我们将降低项目的刷新率来降低耗电。
 
 在移动设备上UI绘制的流畅度受到GC影响较大。如有卡顿，例如滑动掉帧。可开启OnDemandGC, UIWidgets将接管并优化整体GC效果，请在代码中设置```UIWidgetsGlobalConfiguration.EnableIncrementalGC = true```,并开启```Project Setting -> Player -> Other Settings -> Use incremental GC```。

--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ want to show the status bar in your App, you can disable```Start in fullscreen``
 #### Image Import Setting
 Please put images under StreamingAssets folder, a and loading it using ```Image.file```.
 
+#### Show External Texture
+You can use the new builtin API ``UIWidgetsExternalTextureHelper.createCompatibleExternalTexture`` to create a compatible render texture in Unity and render it on a ``Texture`` widget in UIWidgets. With the feature, you can easily embed 3d models, videos, etc.
+in your App. 
+
+Note that currently this feature is only supported for **OpenGLCore** (Mac), **OpenGLes** (iOS&Android) and **D3D11** (Windows) with **Unity 2020.3.37f1c1** and newer. A simple example (i.e., ``3DTest1.unity``) can be found in our sample project.
+
 #### Performance Optimization on Mobile devices
 By setting ```UIWidgetsGlobalConfiguration.EnableAutoAdjustFramerate = true``` in your project, UIWidgets will drop the frame rate of your App to 0 if the UI contents of UIWidgetsPanel is not changed for some time. This will help to prevent battery drain on mobile devices significantly. Note that this feature is disabled by default.
 

--- a/Samples/UIWidgetsSamples_2019_4/Assets/Scene/3DTest1.unity
+++ b/Samples/UIWidgetsSamples_2019_4/Assets/Scene/3DTest1.unity
@@ -43,7 +43,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 12
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_LightingSettings: {fileID: 0}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -118,6 +118,8 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -165,7 +167,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 280715822}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d453ee00c75145f793bc44c5e68e290c, type: 3}
   m_Name: 
@@ -173,6 +175,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -462,6 +465,7 @@ Light:
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &1465388157
@@ -496,7 +500,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &1895879420
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -536,6 +540,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!223 &1895879422
 Canvas:
   m_ObjectHideFlags: 0
@@ -577,72 +582,3 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!1001 &1924659856
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 606295237490439666, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_Name
-      value: CubPrefab
-      objectReference: {fileID: 0}
-    - target: {fileID: 606295237490439667, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 606295237490439667, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 606295237490439667, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 606295237490439667, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 606295237490439667, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 606295237490439667, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 606295237490439667, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 606295237490439667, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 606295237490439667, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 606295237490439667, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 606295237490439667, guid: adca91dcd1cc06a408c4320cddda1c0e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: adca91dcd1cc06a408c4320cddda1c0e, type: 3}

--- a/Samples/UIWidgetsSamples_2019_4/Assets/Script/ModelViewHelper.cs
+++ b/Samples/UIWidgetsSamples_2019_4/Assets/Script/ModelViewHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Unity.UIWidgets.engine;
 using Unity.UIWidgets.foundation;
 using UnityEngine;
 
@@ -81,7 +82,12 @@ namespace UIWidgetsSample
             
             var gameObj = (GameObject) Instantiate(modelViewPrefab, Vector3.zero, Quaternion.identity);
             
-            var renderTexture = new RenderTexture(100, 100, 32);
+            var renderTexture = UIWidgetsExternalTextureHelper.createCompatibleExternalTexture(new RenderTextureDescriptor(
+                width: 100, height: 100
+                )
+            {
+                depthBufferBits = 32
+            });
 
             gameObj.transform.Find("Camera").GetComponent<Camera>().targetTexture = renderTexture;
             

--- a/Samples/UIWidgetsSamples_2019_4/Assets/Script/Scene3DTest1.cs
+++ b/Samples/UIWidgetsSamples_2019_4/Assets/Script/Scene3DTest1.cs
@@ -8,6 +8,7 @@ using Unity.UIWidgets.widgets;
 using UnityEngine;
 using Color = Unity.UIWidgets.ui.Color;
 using Image = Unity.UIWidgets.widgets.Image;
+using TextStyle = Unity.UIWidgets.painting.TextStyle;
 using Texture = Unity.UIWidgets.widgets.Texture;
 using ui_ = Unity.UIWidgets.widgets.ui_;
 
@@ -62,8 +63,8 @@ namespace UIWidgetsSample
                     child: new Column(
                         children: new List<Widget>
                         {
-                            new Lottie("wine.json", size: new Size(100, 100)),
-                            new Container(width: 200, height: 200, color: Colors.red, child: new Center(child: new Container(width: 100, height: 100, child:new Texture(texture: text)))),
+                            new Text("External Texture is Only Available on OpenGLCore (Mac), OpenGLes(iOS and android) and D3d11(Windows)", style: new TextStyle(fontSize: 16f, decoration: TextDecoration.none, color: Colors.red)),
+                            new Container(width: 120, height: 120, color: Colors.red, child: new Center(child: new Container(width: 100, height: 100, child:new Texture(texture: text)))),
                             /*new Container(
                                 width: 100,
                                 height: 100,

--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsExternalTextureRegistry.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsExternalTextureRegistry.cs
@@ -1,8 +1,20 @@
 using System;
 using System.Collections.Generic;
 using Unity.UIWidgets.foundation;
+using UnityEngine;
 
 namespace Unity.UIWidgets.engine {
+    public static class UIWidgetsExternalTextureHelper {
+        public static RenderTexture createCompatibleExternalTexture(RenderTextureDescriptor descriptor) {
+#if UNITY_2020_3_OR_NEWER && !UNITY_2020_3_1 && !UNITY_2020_3_2 && !UNITY_2020_3_3 && !UNITY_2020_3_4&& !UNITY_2020_3_5 && !UNITY_2020_3_6 && !UNITY_2020_3_7 && !UNITY_2020_3_8 && !UNITY_2020_3_9 && !UNITY_2020_3_10&& !UNITY_2020_3_11&& !UNITY_2020_3_12 && !UNITY_2020_3_13 && !UNITY_2020_3_14 && !UNITY_2020_3_15 && !UNITY_2020_3_16 && !UNITY_2020_3_17 && !UNITY_2020_3_18 && !UNITY_2020_3_19 && !UNITY_2020_3_20 && !UNITY_2020_3_21 && !UNITY_2020_3_22 && !UNITY_2020_3_23 && !UNITY_2020_3_24 && !UNITY_2020_3_25 && !UNITY_2020_3_26 && !UNITY_2020_3_27 && !UNITY_2020_3_28 && !UNITY_2020_3_29 && !UNITY_2020_3_30 && !UNITY_2020_3_31 && !UNITY_2020_3_32 && !UNITY_2020_3_33 && !UNITY_2020_3_34 && !UNITY_2020_3_35 && !UNITY_2020_3_36
+            //this API is only available for 2020.3.37 and later Unity
+            return UIWidgetsInternal.CreateBindableRenderTexture(descriptor);
+#else
+            return new RenderTexture(descriptor);
+#endif
+        }
+    }
+    
     public partial class UIWidgetsPanelWrapper {
         readonly Dictionary<IntPtr, int> externalTextures = new Dictionary<IntPtr, int>();
 


### PR DESCRIPTION
In this PR we use the new Unity API: **UIWidgetsInternal.CreateBindableRenderTexture** to create compatible external texture for uiwidgets