### PR TITLE
fix oom bug

### DIFF
--- a/com.unity.uiwidgets/Runtime/Plugins/Android/arm64/libUIWidgets.so
+++ b/com.unity.uiwidgets/Runtime/Plugins/Android/arm64/libUIWidgets.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a45b88658551d431f33e90b2fcb652e6e7caf198e3b7ddd981eccaa28d467c61
-size 84478088
+oid sha256:305d94ffd996747ddfeaf55bf2fed4b9d5550ef7fe2e519fcabdb562db49d330
+size 84478472

--- a/com.unity.uiwidgets/Runtime/Plugins/Android/libUIWidgets.so
+++ b/com.unity.uiwidgets/Runtime/Plugins/Android/libUIWidgets.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3fd4a0274ec01ecbe165fffca9f19c56c5102084c5ee456291db2187f2707d32
-size 77019368
+oid sha256:9987c26aeeb53a37b9a04ea551c70e0b0e58e2750c0318abddc8e75c176a0136
+size 77019504

--- a/com.unity.uiwidgets/Runtime/Plugins/ios/libUIWidgets.a
+++ b/com.unity.uiwidgets/Runtime/Plugins/ios/libUIWidgets.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6efe231a006f1af3b35b1921703d2e7ce6f8f4b0cb186219a7f0fc326c8b60a9
-size 243846216
+oid sha256:b4f0aa74158a97577dfbd17da0faf4b34e6d31197bad2747c6376cf261700d3d
+size 243549592

--- a/com.unity.uiwidgets/Runtime/Plugins/osx/libUIWidgets.dylib
+++ b/com.unity.uiwidgets/Runtime/Plugins/osx/libUIWidgets.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37cb1fb7caf005e5ce9c8701047f1ef2dd0c74b02615c824143bcd99e154e7ff
+oid sha256:0774df0222392c3908e14c4ac9b135ca84ece30bdd930ee651b2936ae49e9e19
 size 21783600

--- a/com.unity.uiwidgets/Runtime/Plugins/x86_64/libUIWidgets.dll
+++ b/com.unity.uiwidgets/Runtime/Plugins/x86_64/libUIWidgets.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a284ce4a15639347bc4371fdc5d4c5c602be836297accfec0f2b1d0e4267e68
-size 11261952
+oid sha256:677109a2f5a7d88c1cfe4a653e1b911696bdc7afbf072846aaa5628fdcb658bd
+size 11260416

--- a/com.unity.uiwidgets/Runtime/rendering/flow.cs
+++ b/com.unity.uiwidgets/Runtime/rendering/flow.cs
@@ -8,9 +8,9 @@ namespace Unity.UIWidgets.rendering {
 
         int childCount { get; }
 
-        public Size getChildSize(int i);
+        Size getChildSize(int i);
 
-        public void paintChild(int i, Matrix4 transform = null, float opacity = 1.0f);
+        void paintChild(int i, Matrix4 transform = null, float opacity = 1.0f);
     }
 
     public abstract class FlowDelegate {
@@ -161,7 +161,7 @@ namespace Unity.UIWidgets.rendering {
         }
 
         public void paintChild(int i, Matrix4 transform = null, float opacity = 1.0f) {
-            transform ??= Matrix4.identity();
+            transform = transform ?? Matrix4.identity();
             RenderBox child = _randomAccessChildren[i];
             FlowParentData childParentData = child.parentData as FlowParentData;
             D.assert(() => {
@@ -233,8 +233,8 @@ namespace Unity.UIWidgets.rendering {
                 bool absorbed = result.addWithPaintTransform(
                     transform: transform,
                     position: position,
-                    hitTest: (BoxHitTestResult result, Offset position) => {
-                        return child.hitTest(result, position: position);
+                    hitTest: (BoxHitTestResult result2, Offset position2) => {
+                        return child.hitTest(result2, position: position2);
                     }
                 );
                 if (absorbed)

--- a/com.unity.uiwidgets/Runtime/rendering/proxy_box.cs
+++ b/com.unity.uiwidgets/Runtime/rendering/proxy_box.cs
@@ -762,16 +762,18 @@ namespace Unity.UIWidgets.rendering {
         public override void paint(PaintingContext context, Offset offset) {
             if (child != null) {
                 if (_alpha == 0) {
+                    layer = null;
                     return;
                 }
 
                 if (_alpha == 255) {
+                    layer = null;
                     context.paintChild(child, offset);
                     return;
                 }
-
+                
                 D.assert(needsCompositing);
-                context.pushOpacity(offset, _alpha, base.paint);
+                layer = context.pushOpacity(offset, _alpha, base.paint, layer as OpacityLayer);
             }
         }
 

--- a/engine/Build.bee.cs
+++ b/engine/Build.bee.cs
@@ -805,7 +805,7 @@ class Build
         //
         //Disable the persistent cache (via force its IsValid() method to always return false) in UIWidget engine for Mac
         //note that there might be some performance issue (mainly first frame delay) after this fix on Mac
-        np.Defines.Add(c => IsMac(c), "UIWIDGETS_FORCE_DISABLE_PERSISTENTCACHE=\\\"1\\\"");
+        np.Defines.Add(c => IsMac(c) || IsIosOrTvos(c), "UIWIDGETS_FORCE_DISABLE_PERSISTENTCACHE=\\\"1\\\"");
 
         np.Defines.Add(c => c.CodeGen == CodeGen.Debug,
             new[] { "_ITERATOR_DEBUG_LEVEL=2", "_HAS_ITERATOR_DEBUGGING=1", "_SECURE_SCL=1" });

--- a/engine/src/shell/common/rasterizer.cc
+++ b/engine/src/shell/common/rasterizer.cc
@@ -88,6 +88,7 @@ void Rasterizer::DrawLastLayerTree() {
     return;
   }
   DrawToSurface(*last_layer_tree_);
+  surface_->ClearContext();
 }
 
 void Rasterizer::Draw(fml::RefPtr<Pipeline<LayerTree>> pipeline) {
@@ -232,6 +233,8 @@ RasterStatus Rasterizer::DoDraw(std::unique_ptr<LayerTree> layer_tree) {
   persistent_cache->ResetStoredNewShaders();
 
   RasterStatus raster_status = DrawToSurface(*layer_tree);
+  surface_->ClearContext();
+
   if (raster_status == RasterStatus::kSuccess) {
     last_layer_tree_ = std::move(layer_tree);
   } else if (raster_status == RasterStatus::kResubmit) {
@@ -325,7 +328,6 @@ RasterStatus Rasterizer::DrawToSurface(LayerTree& layer_tree) {
   if (compositor_frame) {
     RasterStatus raster_status = compositor_frame->Raster(layer_tree, false);
     if (raster_status == RasterStatus::kFailed) {
-      surface_->ClearContext();
       return raster_status;
     }
     if (external_view_embedder != nullptr) {
@@ -347,11 +349,9 @@ RasterStatus Rasterizer::DrawToSurface(LayerTree& layer_tree) {
       TRACE_EVENT0("uiwidgets", "PerformDeferredSkiaCleanup");
       surface_->GetContext()->performDeferredCleanup(kSkiaCleanupExpiration);
     }
-    surface_->ClearContext();
     return raster_status;
   }
   
-  surface_->ClearContext();
   return RasterStatus::kFailed;
 }
 


### PR DESCRIPTION
In this PR we aims to fix a potential OOM bug observed on android/ios devices.

The bug is caused by the fact that: in one frame, a CompositorContext is used to preroll and the paint the layer tree which holds a rasterize cache to boost the performance. Generally, it will first generate the cache in the preroll call and then at the end of the frame, it will release unused cache when the unique pointer of `compositor_frame` is released and the method `CompositorContext::ScopedFrame::~ScopedFrame()` is called. Note that since the cache holds shared memory between gpu and cpu, it is important to keep a valid gpu context while doing the release job.

However, in one PR I made before, it mistakenly clears the gpu context before the `compositor_frame` is released (which happens when the whole function is finished and the specific unique pointer is out of scope). As the result, the gpu side memory might be unable to be released properly.

To fix this issue, we just guarantee that we clear the gpu context only after the `compositor_frame` is released